### PR TITLE
get_permissions

### DIFF
--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",

--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",

--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",

--- a/bindings/typescript-arkade/src/nodes/arkade-boltz.ts
+++ b/bindings/typescript-arkade/src/nodes/arkade-boltz.ts
@@ -29,6 +29,16 @@ import type {
 
 type ArkadeRuntimeNetwork = 'bitcoin' | 'testnet' | 'signet' | 'mutinynet' | 'regtest';
 
+const ARKADE_BOLTZ_NODE_PERMISSIONS = [
+  'getInfo',
+  'createInvoice',
+  'payInvoice',
+  'lookupInvoice',
+  'listTransactions',
+  'decode',
+  'onInvoiceEvents',
+] as const;
+
 type ArkadeWalletLike = {
   networkName?: ArkadeRuntimeNetwork;
   getBalance(): Promise<{ available?: unknown }>;
@@ -342,6 +352,10 @@ export class ArkadeBoltzNode implements LightningNode {
     }
 
     return txs;
+  }
+
+  async getPermissions(): Promise<string[]> {
+    return [...ARKADE_BOLTZ_NODE_PERMISSIONS];
   }
 
   async getInfo(): Promise<NodeInfo> {

--- a/bindings/typescript-arkade/src/nodes/arkade-boltz.ts
+++ b/bindings/typescript-arkade/src/nodes/arkade-boltz.ts
@@ -16,6 +16,7 @@ import {
   type OnInvoiceEventParams,
   type PayInvoiceParams,
   type PayInvoiceResponse,
+  type Permissions,
   type Transaction,
 } from '@sunnyln/lni';
 import { pollInvoiceEvents } from '@sunnyln/lni/internal/polling';
@@ -29,15 +30,19 @@ import type {
 
 type ArkadeRuntimeNetwork = 'bitcoin' | 'testnet' | 'signet' | 'mutinynet' | 'regtest';
 
-const ARKADE_BOLTZ_NODE_PERMISSIONS = [
-  'getInfo',
-  'createInvoice',
-  'payInvoice',
-  'lookupInvoice',
-  'listTransactions',
-  'decode',
-  'onInvoiceEvents',
-] as const;
+const ARKADE_BOLTZ_NODE_PERMISSIONS: Permissions = {
+  getInfo: true,
+  createInvoice: true,
+  payInvoice: true,
+  createOffer: false,
+  getOffer: false,
+  listOffers: false,
+  payOffer: false,
+  lookupInvoice: true,
+  listTransactions: true,
+  decode: true,
+  onInvoiceEvents: true,
+};
 
 type ArkadeWalletLike = {
   networkName?: ArkadeRuntimeNetwork;
@@ -354,8 +359,8 @@ export class ArkadeBoltzNode implements LightningNode {
     return txs;
   }
 
-  async getPermissions(): Promise<string[]> {
-    return [...ARKADE_BOLTZ_NODE_PERMISSIONS];
+  async getPermissions(): Promise<Permissions> {
+    return { ...ARKADE_BOLTZ_NODE_PERMISSIONS };
   }
 
   async getInfo(): Promise<NodeInfo> {

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",

--- a/bindings/typescript-spark/src/__tests__/spark-node.test.ts
+++ b/bindings/typescript-spark/src/__tests__/spark-node.test.ts
@@ -41,6 +41,16 @@ describe('SparkNode payInvoice', () => {
     ).rejects.toThrow('Spark amountless invoice requires amountMsats.');
   });
 
+  it('rejects permission introspection for wallet credentials', async () => {
+    const { SparkNode } = await import('../nodes/spark.js');
+    const node = new SparkNode({
+      mnemonic: TEST_MNEMONIC,
+      sdkEntry: 'bare',
+    });
+
+    await expect(node.getPermissions()).rejects.toThrow('Spark wallet credentials cannot be introspected.');
+  });
+
   it('does not send amountSatsToSend for fixed-amount invoice', async () => {
     mockBolt11Decoder({ amountMsats: '118000' });
     const { SparkNode } = await import('../nodes/spark.js');

--- a/bindings/typescript-spark/src/nodes/spark.ts
+++ b/bindings/typescript-spark/src/nodes/spark.ts
@@ -1300,6 +1300,13 @@ export class SparkNode implements LightningNode {
     return this.walletPromise;
   }
 
+  async getPermissions(): Promise<string[]> {
+    throw new LniError(
+      'InvalidInput',
+      'Spark wallet credentials cannot be introspected. Manually test permissions against Spark wallet operations.',
+    );
+  }
+
   async getInfo(): Promise<NodeInfo> {
     const wallet = await this.getWallet();
     const [balance, identityPublicKey] = await Promise.all([

--- a/bindings/typescript-spark/src/nodes/spark.ts
+++ b/bindings/typescript-spark/src/nodes/spark.ts
@@ -24,7 +24,7 @@ import {
 } from '../vendor/frosts-bridge.js';
 import { decrypt as eciesDecrypt, encrypt as eciesEncrypt } from 'eciesjs';
 import { decode as decodeBolt11 } from 'light-bolt11-decoder';
-import { LniError, InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type StorageProvider, type Transaction } from '@sunnyln/lni';
+import { LniError, InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type StorageProvider, type Transaction } from '@sunnyln/lni';
 import { bytesToHex, hexToBytes } from '@sunnyln/lni/internal/encoding';
 import { pollInvoiceEvents } from '@sunnyln/lni/internal/polling';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, toUnixSeconds } from '@sunnyln/lni/internal/transform';
@@ -1300,7 +1300,7 @@ export class SparkNode implements LightningNode {
     return this.walletPromise;
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     throw new LniError(
       'InvalidInput',
       'Spark wallet credentials cannot be introspected. Manually test permissions against Spark wallet operations.',

--- a/bindings/typescript/README.md
+++ b/bindings/typescript/README.md
@@ -38,6 +38,7 @@ const backend: BackendNodeConfig = {
 const node = createNode(backend);
 
 const info = await node.getInfo();
+const permissions = await node.getPermissions();
 
 const invoiceParams = {
   invoiceType: InvoiceType.Bolt11,

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",
@@ -59,9 +59,10 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.build.json",
+    "types:sync": "npm run clean && npm run typecheck && npm run build",
     "example": "npm run build && npm --prefix ../typescript-arkade run build && npm --prefix ../typescript-spark run build && npm --prefix ../typescript-spark/examples/spark-web install && npm --prefix ../typescript-spark/examples/spark-web run dev",
-    "release:dry-run": "npm run pack:dry-run && npm --prefix ../typescript-arkade run pack:dry-run && npm --prefix ../typescript-spark run pack:dry-run",
-    "release:public": "npm run publish:public && npm --prefix ../typescript-arkade run publish:public && npm --prefix ../typescript-spark run publish:public",
+    "release:dry-run": "npm run types:sync && npm run pack:dry-run && npm --prefix ../typescript-arkade run pack:dry-run && npm --prefix ../typescript-spark run pack:dry-run",
+    "release:public": "npm run types:sync && npm run publish:public && npm --prefix ../typescript-arkade run publish:public && npm --prefix ../typescript-spark run publish:public",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "prepack": "npm run clean && npm run typecheck && npm run build",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",

--- a/bindings/typescript/src/__tests__/permissions.test.ts
+++ b/bindings/typescript/src/__tests__/permissions.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { encodeBase64Bytes } from '../internal/encoding.js';
+import { getBlinkTokenPermissions, getStrikeOauthPermissions, parseClnRunePermissions } from '../internal/permissions.js';
+import { BlinkNode } from '../nodes/blink.js';
+import { LndNode } from '../nodes/lnd.js';
+import { PhoenixdNode } from '../nodes/phoenixd.js';
+import { SpeedNode } from '../nodes/speed.js';
+import { StrikeNode } from '../nodes/strike.js';
+
+describe('permissions helpers', () => {
+  it('expands CLN method prefix rune restrictions to known methods', () => {
+    const raw = new TextEncoder().encode('unique-id&method^list|method=getinfo');
+    const rune = encodeBase64Bytes(raw).replace(/\+/g, '-').replace(/\//g, '_');
+
+    expect(parseClnRunePermissions(rune)).toEqual([
+      'getinfo',
+      'listfunds',
+      'listinvoices',
+      'listoffers',
+    ]);
+  });
+
+  it('checks LND macaroon permissions against the node permission map', async () => {
+    const node = new LndNode(
+      {
+        url: 'https://lnd.example.test',
+        macaroon: '00',
+      },
+      {
+        fetch: async (input, init) => {
+          const url = String(input);
+
+          if (url.endsWith('/v1/macaroon/permissions')) {
+            return Response.json({
+              method_permissions: {
+                '/lnrpc.Lightning/GetInfo': {
+                  permissions: [{ entity: 'info', action: 'read' }],
+                },
+                '/lnrpc.Lightning/AddInvoice': {
+                  permissions: [{ entity: 'invoices', action: 'write' }],
+                },
+              },
+            });
+          }
+
+          if (url.endsWith('/v1/macaroon/checkpermissions')) {
+            const body = JSON.parse(String(init?.body));
+            return Response.json({
+              valid: body.permissions?.[0]?.entity === 'info',
+            });
+          }
+
+          return new Response('not found', { status: 404 });
+        },
+      },
+    );
+
+    await expect(node.getPermissions()).resolves.toEqual(['/lnrpc.Lightning/GetInfo']);
+  });
+
+  it('maps Strike OAuth JWT scopes to LNI permissions', () => {
+    const accessToken = [
+      encodeJwtPart({ alg: 'none' }),
+      encodeJwtPart({
+        scope: [
+          'openid',
+          'partner.balances.read',
+          'partner.receive-request.create',
+          'partner.receive-request.read',
+          'partner.payment-quote.lightning.create',
+          'partner.payment-quote.execute',
+        ].join(' '),
+      }),
+      'signature',
+    ].join('.');
+
+    expect(getStrikeOauthPermissions(accessToken)).toEqual([
+      'createInvoice',
+      'decode',
+      'getInfo',
+      'lookupInvoice',
+      'onInvoiceEvents',
+      'payInvoice',
+    ]);
+  });
+
+  it('rejects opaque Strike API keys for permission introspection', async () => {
+    const node = new StrikeNode({ apiKey: 'sk_test_opaque' });
+
+    await expect(node.getPermissions()).rejects.toMatchObject({
+      code: 'InvalidInput',
+    });
+  });
+
+  it('maps Blink JWT scopes to LNI permissions', () => {
+    const token = [
+      encodeJwtPart({ alg: 'none' }),
+      encodeJwtPart({ scope: 'Read Receive Write' }),
+      'signature',
+    ].join('.');
+
+    expect(getBlinkTokenPermissions(token)).toEqual([
+      'createInvoice',
+      'decode',
+      'getInfo',
+      'listTransactions',
+      'lookupInvoice',
+      'onInvoiceEvents',
+      'payInvoice',
+    ]);
+  });
+
+  it('rejects opaque Blink API keys for permission introspection', async () => {
+    const node = new BlinkNode({ apiKey: 'blink_opaque' });
+
+    await expect(node.getPermissions()).rejects.toMatchObject({
+      code: 'InvalidInput',
+    });
+  });
+
+  it('rejects Speed API keys for permission introspection', async () => {
+    const node = new SpeedNode({ apiKey: 'sk_test_opaque' });
+
+    await expect(node.getPermissions()).rejects.toMatchObject({
+      code: 'InvalidInput',
+    });
+  });
+
+  it('rejects Phoenixd passwords for permission introspection', async () => {
+    const node = new PhoenixdNode({ url: 'https://phoenixd.example.test', password: 'secret' });
+
+    await expect(node.getPermissions()).rejects.toMatchObject({
+      code: 'InvalidInput',
+    });
+  });
+});
+
+function encodeJwtPart(value: unknown): string {
+  return encodeBase64Bytes(new TextEncoder().encode(JSON.stringify(value)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}

--- a/bindings/typescript/src/__tests__/permissions.test.ts
+++ b/bindings/typescript/src/__tests__/permissions.test.ts
@@ -6,18 +6,21 @@ import { LndNode } from '../nodes/lnd.js';
 import { PhoenixdNode } from '../nodes/phoenixd.js';
 import { SpeedNode } from '../nodes/speed.js';
 import { StrikeNode } from '../nodes/strike.js';
+import type { Permissions } from '../types.js';
 
 describe('permissions helpers', () => {
   it('expands CLN method prefix rune restrictions to known methods', () => {
     const raw = new TextEncoder().encode('unique-id&method^list|method=getinfo');
     const rune = encodeBase64Bytes(raw).replace(/\+/g, '-').replace(/\//g, '_');
 
-    expect(parseClnRunePermissions(rune)).toEqual([
-      'getinfo',
-      'listfunds',
-      'listinvoices',
-      'listoffers',
-    ]);
+    expect(parseClnRunePermissions(rune)).toEqual(permissions({
+      getInfo: true,
+      getOffer: true,
+      listOffers: true,
+      lookupInvoice: true,
+      listTransactions: true,
+      onInvoiceEvents: true,
+    }));
   });
 
   it('checks LND macaroon permissions against the node permission map', async () => {
@@ -36,6 +39,9 @@ describe('permissions helpers', () => {
                 '/lnrpc.Lightning/GetInfo': {
                   permissions: [{ entity: 'info', action: 'read' }],
                 },
+                '/lnrpc.Lightning/ChannelBalance': {
+                  permissions: [{ entity: 'offchain', action: 'read' }],
+                },
                 '/lnrpc.Lightning/AddInvoice': {
                   permissions: [{ entity: 'invoices', action: 'write' }],
                 },
@@ -46,7 +52,7 @@ describe('permissions helpers', () => {
           if (url.endsWith('/v1/macaroon/checkpermissions')) {
             const body = JSON.parse(String(init?.body));
             return Response.json({
-              valid: body.permissions?.[0]?.entity === 'info',
+              valid: ['info', 'offchain'].includes(body.permissions?.[0]?.entity),
             });
           }
 
@@ -55,7 +61,9 @@ describe('permissions helpers', () => {
       },
     );
 
-    await expect(node.getPermissions()).resolves.toEqual(['/lnrpc.Lightning/GetInfo']);
+    await expect(node.getPermissions()).resolves.toEqual(permissions({
+      getInfo: true,
+    }));
   });
 
   it('maps Strike OAuth JWT scopes to LNI permissions', () => {
@@ -74,14 +82,14 @@ describe('permissions helpers', () => {
       'signature',
     ].join('.');
 
-    expect(getStrikeOauthPermissions(accessToken)).toEqual([
-      'createInvoice',
-      'decode',
-      'getInfo',
-      'lookupInvoice',
-      'onInvoiceEvents',
-      'payInvoice',
-    ]);
+    expect(getStrikeOauthPermissions(accessToken)).toEqual(permissions({
+      getInfo: true,
+      createInvoice: true,
+      payInvoice: true,
+      lookupInvoice: true,
+      decode: true,
+      onInvoiceEvents: true,
+    }));
   });
 
   it('rejects opaque Strike API keys for permission introspection', async () => {
@@ -99,15 +107,15 @@ describe('permissions helpers', () => {
       'signature',
     ].join('.');
 
-    expect(getBlinkTokenPermissions(token)).toEqual([
-      'createInvoice',
-      'decode',
-      'getInfo',
-      'listTransactions',
-      'lookupInvoice',
-      'onInvoiceEvents',
-      'payInvoice',
-    ]);
+    expect(getBlinkTokenPermissions(token)).toEqual(permissions({
+      getInfo: true,
+      createInvoice: true,
+      payInvoice: true,
+      lookupInvoice: true,
+      listTransactions: true,
+      decode: true,
+      onInvoiceEvents: true,
+    }));
   });
 
   it('rejects opaque Blink API keys for permission introspection', async () => {
@@ -140,4 +148,27 @@ function encodeJwtPart(value: unknown): string {
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/g, '');
+}
+
+function permissions(overrides: Partial<Permissions>): Permissions {
+  return {
+    ...emptyPermissions(),
+    ...overrides,
+  };
+}
+
+function emptyPermissions() {
+  return {
+    getInfo: false,
+    createInvoice: false,
+    payInvoice: false,
+    createOffer: false,
+    getOffer: false,
+    listOffers: false,
+    payOffer: false,
+    lookupInvoice: false,
+    listTransactions: false,
+    decode: false,
+    onInvoiceEvents: false,
+  };
 }

--- a/bindings/typescript/src/internal/encoding.ts
+++ b/bindings/typescript/src/internal/encoding.ts
@@ -29,6 +29,25 @@ export function encodeBase64(input: string): string {
   return output;
 }
 
+export function encodeBase64Bytes(bytes: Uint8Array): string {
+  let output = '';
+
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i] ?? 0;
+    const b = bytes[i + 1] ?? 0;
+    const c = bytes[i + 2] ?? 0;
+
+    const triple = (a << 16) | (b << 8) | c;
+
+    output += BASE64_CHARS[(triple >> 18) & 63];
+    output += BASE64_CHARS[(triple >> 12) & 63];
+    output += i + 1 < bytes.length ? BASE64_CHARS[(triple >> 6) & 63] : '=';
+    output += i + 2 < bytes.length ? BASE64_CHARS[triple & 63] : '=';
+  }
+
+  return output;
+}
+
 export function decodeBase64(input: string): Uint8Array {
   const normalized = input.replace(/\s+/g, '');
 

--- a/bindings/typescript/src/internal/permissions.ts
+++ b/bindings/typescript/src/internal/permissions.ts
@@ -1,0 +1,236 @@
+import { decodeBase64 } from './encoding.js';
+
+export const PERMISSION_GET_INFO = 'getInfo';
+export const PERMISSION_CREATE_INVOICE = 'createInvoice';
+export const PERMISSION_PAY_INVOICE = 'payInvoice';
+export const PERMISSION_CREATE_OFFER = 'createOffer';
+export const PERMISSION_GET_OFFER = 'getOffer';
+export const PERMISSION_LIST_OFFERS = 'listOffers';
+export const PERMISSION_PAY_OFFER = 'payOffer';
+export const PERMISSION_LOOKUP_INVOICE = 'lookupInvoice';
+export const PERMISSION_LIST_TRANSACTIONS = 'listTransactions';
+export const PERMISSION_DECODE = 'decode';
+export const PERMISSION_ON_INVOICE_EVENTS = 'onInvoiceEvents';
+
+export const BOLT11_NODE_PERMISSIONS = [
+  PERMISSION_GET_INFO,
+  PERMISSION_CREATE_INVOICE,
+  PERMISSION_PAY_INVOICE,
+  PERMISSION_LOOKUP_INVOICE,
+  PERMISSION_LIST_TRANSACTIONS,
+  PERMISSION_DECODE,
+  PERMISSION_ON_INVOICE_EVENTS,
+] as const;
+
+export const BOLT12_NODE_PERMISSIONS = [
+  PERMISSION_CREATE_OFFER,
+  PERMISSION_GET_OFFER,
+  PERMISSION_LIST_OFFERS,
+  PERMISSION_PAY_OFFER,
+] as const;
+
+export const FULL_NODE_PERMISSIONS = [
+  ...BOLT11_NODE_PERMISSIONS,
+  ...BOLT12_NODE_PERMISSIONS,
+] as const;
+
+export const NWC_METHOD_PERMISSIONS = [
+  'get_info',
+  'get_balance',
+  'make_invoice',
+  'pay_invoice',
+  'lookup_invoice',
+  'list_transactions',
+] as const;
+
+export const CLN_METHOD_PERMISSIONS = [
+  'getinfo',
+  'listfunds',
+  'invoice',
+  'pay',
+  'offer',
+  'fetchinvoice',
+  'listoffers',
+  'listinvoices',
+  'decode',
+] as const;
+
+const STRIKE_SCOPE_PERMISSIONS: Array<{
+  permission: string;
+  scopes: string[];
+}> = [
+  {
+    permission: PERMISSION_GET_INFO,
+    scopes: ['partner.balances.read'],
+  },
+  {
+    permission: PERMISSION_CREATE_INVOICE,
+    scopes: ['partner.receive-request.create'],
+  },
+  {
+    permission: PERMISSION_PAY_INVOICE,
+    scopes: [
+      'partner.payment-quote.lightning.create',
+      'partner.payment-quote.execute',
+    ],
+  },
+  {
+    permission: PERMISSION_LOOKUP_INVOICE,
+    scopes: ['partner.receive-request.read'],
+  },
+  {
+    permission: PERMISSION_LIST_TRANSACTIONS,
+    scopes: ['partner.receive-request.read', 'partner.payment.read'],
+  },
+  {
+    permission: PERMISSION_ON_INVOICE_EVENTS,
+    scopes: ['partner.receive-request.read'],
+  },
+];
+
+const BLINK_SCOPE_PERMISSIONS: Array<{
+  permission: string;
+  scopes: string[];
+}> = [
+  {
+    permission: PERMISSION_GET_INFO,
+    scopes: ['read'],
+  },
+  {
+    permission: PERMISSION_CREATE_INVOICE,
+    scopes: ['receive'],
+  },
+  {
+    permission: PERMISSION_PAY_INVOICE,
+    scopes: ['write'],
+  },
+  {
+    permission: PERMISSION_LOOKUP_INVOICE,
+    scopes: ['read'],
+  },
+  {
+    permission: PERMISSION_LIST_TRANSACTIONS,
+    scopes: ['read'],
+  },
+  {
+    permission: PERMISSION_ON_INVOICE_EVENTS,
+    scopes: ['read'],
+  },
+];
+
+export function normalizePermissions(values: Iterable<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (normalized) {
+      seen.add(normalized);
+    }
+  }
+
+  return [...seen].sort((a, b) => a.localeCompare(b));
+}
+
+export function parseClnRunePermissions(rune: string): string[] {
+  const decoded = decodeBase64Url(rune);
+  const text = new TextDecoder().decode(decoded);
+  const matches = text.match(/method(?:=|\^)[A-Za-z0-9_.:-]+/g) ?? [];
+
+  if (!matches.length) {
+    return normalizePermissions(CLN_METHOD_PERMISSIONS);
+  }
+
+  const expanded: string[] = [];
+  for (const permission of matches) {
+    if (permission.startsWith('method=')) {
+      expanded.push(permission.slice('method='.length));
+      continue;
+    }
+
+    const prefix = permission.slice('method^'.length);
+    const matchingMethods = CLN_METHOD_PERMISSIONS.filter((method) => method.startsWith(prefix));
+    expanded.push(...(matchingMethods.length ? matchingMethods : [`${prefix}*`]));
+  }
+
+  return normalizePermissions(expanded);
+}
+
+export function parseLndMacaroonPermissions(bytes: Uint8Array): string[] {
+  const text = new TextDecoder().decode(bytes);
+  const matches = text.match(/[a-z][a-z0-9_-]*:(?:read|write|generate)/g) ?? [];
+  return normalizePermissions(matches);
+}
+
+export function getStrikeOauthPermissions(accessToken: string): string[] | null {
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload) {
+    return null;
+  }
+
+  const scopes = new Set(readScopeValues(payload));
+  const permissions = [PERMISSION_DECODE];
+
+  for (const candidate of STRIKE_SCOPE_PERMISSIONS) {
+    if (candidate.scopes.every((scope) => scopes.has(scope))) {
+      permissions.push(candidate.permission);
+    }
+  }
+
+  return normalizePermissions(permissions);
+}
+
+export function getBlinkTokenPermissions(token: string): string[] | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload) {
+    return null;
+  }
+
+  const scopes = new Set(readScopeValues(payload).map((scope) => scope.toLowerCase()));
+  const permissions = [PERMISSION_DECODE];
+
+  for (const candidate of BLINK_SCOPE_PERMISSIONS) {
+    if (candidate.scopes.every((scope) => scopes.has(scope))) {
+      permissions.push(candidate.permission);
+    }
+  }
+
+  return normalizePermissions(permissions);
+}
+
+function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
+  const parts = accessToken.split('.');
+  const payload = parts[1];
+  if (parts.length < 3 || !payload) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(decodeBase64Url(payload))) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function readScopeValues(payload: Record<string, unknown>): string[] {
+  const values = [payload.scope, payload.scp, payload.scopes];
+  const scopes: string[] = [];
+
+  for (const value of values) {
+    if (typeof value === 'string') {
+      scopes.push(...value.split(/\s+/));
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      scopes.push(...value.filter((item): item is string => typeof item === 'string'));
+    }
+  }
+
+  return normalizePermissions(scopes);
+}
+
+function decodeBase64Url(input: string): Uint8Array {
+  const normalized = input.trim().replace(/-/g, '+').replace(/_/g, '/');
+  const padding = (4 - (normalized.length % 4 || 4)) % 4;
+  return decodeBase64(normalized + '='.repeat(padding));
+}

--- a/bindings/typescript/src/internal/permissions.ts
+++ b/bindings/typescript/src/internal/permissions.ts
@@ -1,4 +1,5 @@
 import { decodeBase64 } from './encoding.js';
+import type { Permissions } from '../types.js';
 
 export const PERMISSION_GET_INFO = 'getInfo';
 export const PERMISSION_CREATE_INVOICE = 'createInvoice';
@@ -118,7 +119,27 @@ const BLINK_SCOPE_PERMISSIONS: Array<{
   },
 ];
 
-export function normalizePermissions(values: Iterable<string | null | undefined>): string[] {
+export function emptyPermissions(): Permissions {
+  return {
+    getInfo: false,
+    createInvoice: false,
+    payInvoice: false,
+    createOffer: false,
+    getOffer: false,
+    listOffers: false,
+    payOffer: false,
+    lookupInvoice: false,
+    listTransactions: false,
+    decode: false,
+    onInvoiceEvents: false,
+  };
+}
+
+export function isEmptyPermissions(permissions: Permissions): boolean {
+  return Object.values(permissions).every((value) => !value);
+}
+
+export function normalizePermissionValues(values: Iterable<string | null | undefined>): string[] {
   const seen = new Set<string>();
 
   for (const value of values) {
@@ -131,13 +152,73 @@ export function normalizePermissions(values: Iterable<string | null | undefined>
   return [...seen].sort((a, b) => a.localeCompare(b));
 }
 
-export function parseClnRunePermissions(rune: string): string[] {
+export function normalizePermissions(values: Iterable<string | null | undefined>): Permissions {
+  return permissionsFromValues(compactPermissions(values));
+}
+
+export function normalizeNwcPermissions(values: Iterable<string | null | undefined>): Permissions {
+  const permissions = compactPermissions(values);
+  const has = (permission: string) => hasPermission(permissions, permission);
+
+  return {
+    ...emptyPermissions(),
+    getInfo: has('get_balance'),
+    createInvoice: has('make_invoice'),
+    payInvoice: has('pay_invoice'),
+    lookupInvoice: has('lookup_invoice'),
+    listTransactions: has('list_transactions'),
+    onInvoiceEvents: has('lookup_invoice'),
+  };
+}
+
+export function normalizeClnPermissions(values: Iterable<string | null | undefined>): Permissions {
+  const permissions = compactPermissions(values);
+  const has = (permission: string) => hasPermission(permissions, permission);
+
+  return {
+    getInfo: has('getinfo') && has('listfunds'),
+    createInvoice: has('invoice'),
+    payInvoice: has('pay'),
+    createOffer: has('offer'),
+    getOffer: has('listoffers'),
+    listOffers: has('listoffers'),
+    payOffer: has('fetchinvoice') && has('pay'),
+    lookupInvoice: has('listinvoices'),
+    listTransactions: has('listinvoices'),
+    decode: has('decode'),
+    onInvoiceEvents: has('listinvoices'),
+  };
+}
+
+export function normalizeLndPermissions(values: Iterable<string | null | undefined>): Permissions {
+  const permissions = compactPermissions(values);
+  const has = (permission: string) => hasPermission(permissions, permission);
+
+  return {
+    ...emptyPermissions(),
+    getInfo:
+      (has('/lnrpc.Lightning/GetInfo') && has('/lnrpc.Lightning/ChannelBalance')) ||
+      (has('info:read') && has('offchain:read')),
+    createInvoice: has('/lnrpc.Lightning/AddInvoice') || has('invoices:write'),
+    payInvoice: has('/lnrpc.Lightning/SendPaymentSync') || has('/routerrpc.Router/SendPaymentV2') || has('offchain:write'),
+    lookupInvoice: has('/lnrpc.Lightning/LookupInvoice') || has('invoices:read'),
+    listTransactions:
+      has('/lnrpc.Lightning/ListInvoices') ||
+      has('/lnrpc.Lightning/ListPayments') ||
+      has('invoices:read') ||
+      has('offchain:read'),
+    decode: has('/lnrpc.Lightning/DecodePayReq') || has('offchain:read'),
+    onInvoiceEvents: has('/lnrpc.Lightning/SubscribeInvoices') || has('invoices:read'),
+  };
+}
+
+export function parseClnRunePermissions(rune: string): Permissions {
   const decoded = decodeBase64Url(rune);
   const text = new TextDecoder().decode(decoded);
   const matches = text.match(/method(?:=|\^)[A-Za-z0-9_.:-]+/g) ?? [];
 
   if (!matches.length) {
-    return normalizePermissions(CLN_METHOD_PERMISSIONS);
+    return normalizeClnPermissions(CLN_METHOD_PERMISSIONS);
   }
 
   const expanded: string[] = [];
@@ -152,16 +233,16 @@ export function parseClnRunePermissions(rune: string): string[] {
     expanded.push(...(matchingMethods.length ? matchingMethods : [`${prefix}*`]));
   }
 
-  return normalizePermissions(expanded);
+  return normalizeClnPermissions(expanded);
 }
 
-export function parseLndMacaroonPermissions(bytes: Uint8Array): string[] {
+export function parseLndMacaroonPermissions(bytes: Uint8Array): Permissions {
   const text = new TextDecoder().decode(bytes);
   const matches = text.match(/[a-z][a-z0-9_-]*:(?:read|write|generate)/g) ?? [];
-  return normalizePermissions(matches);
+  return normalizeLndPermissions(matches);
 }
 
-export function getStrikeOauthPermissions(accessToken: string): string[] | null {
+export function getStrikeOauthPermissions(accessToken: string): Permissions | null {
   const payload = decodeJwtPayload(accessToken);
   if (!payload) {
     return null;
@@ -179,7 +260,7 @@ export function getStrikeOauthPermissions(accessToken: string): string[] | null 
   return normalizePermissions(permissions);
 }
 
-export function getBlinkTokenPermissions(token: string): string[] | null {
+export function getBlinkTokenPermissions(token: string): Permissions | null {
   const payload = decodeJwtPayload(token);
   if (!payload) {
     return null;
@@ -195,6 +276,73 @@ export function getBlinkTokenPermissions(token: string): string[] | null {
   }
 
   return normalizePermissions(permissions);
+}
+
+function permissionsFromValues(values: string[]): Permissions {
+  const has = (permission: string) => hasPermission(values, permission);
+
+  return {
+    getInfo:
+      has(PERMISSION_GET_INFO) ||
+      has('get_info') ||
+      has('getinfo') ||
+      has('get_balance') ||
+      has('/lnrpc.Lightning/GetInfo') ||
+      has('/lnrpc.Lightning/ChannelBalance') ||
+      has('info:read'),
+    createInvoice:
+      has(PERMISSION_CREATE_INVOICE) ||
+      has('create_invoice') ||
+      has('make_invoice') ||
+      has('invoice') ||
+      has('/lnrpc.Lightning/AddInvoice') ||
+      has('invoices:write'),
+    payInvoice:
+      has(PERMISSION_PAY_INVOICE) ||
+      has('pay_invoice') ||
+      has('pay') ||
+      has('/lnrpc.Lightning/SendPaymentSync') ||
+      has('/routerrpc.Router/SendPaymentV2') ||
+      has('offchain:write'),
+    createOffer: has(PERMISSION_CREATE_OFFER) || has('create_offer') || has('offer') || has('offers:write'),
+    getOffer: has(PERMISSION_GET_OFFER) || has('get_offer') || has('listoffers') || has('offers:read'),
+    listOffers: has(PERMISSION_LIST_OFFERS) || has('list_offers') || has('listoffers') || has('offers:read'),
+    payOffer: has(PERMISSION_PAY_OFFER) || has('pay_offer') || (has('fetchinvoice') && (has('pay') || has(PERMISSION_PAY_INVOICE))),
+    lookupInvoice:
+      has(PERMISSION_LOOKUP_INVOICE) ||
+      has('lookup_invoice') ||
+      has('lookup-invoice') ||
+      has('listinvoices') ||
+      has('/lnrpc.Lightning/LookupInvoice') ||
+      has('invoices:read'),
+    listTransactions:
+      has(PERMISSION_LIST_TRANSACTIONS) ||
+      has('list_transactions') ||
+      has('listinvoices') ||
+      has('/lnrpc.Lightning/ListInvoices') ||
+      has('/lnrpc.Lightning/ListPayments') ||
+      has('invoices:read') ||
+      has('offchain:read'),
+    decode: has(PERMISSION_DECODE) || has('/lnrpc.Lightning/DecodePayReq') || has('address:read'),
+    onInvoiceEvents:
+      has(PERMISSION_ON_INVOICE_EVENTS) ||
+      has('on_invoice_events') ||
+      has('lookup_invoice') ||
+      has('listinvoices') ||
+      has('/lnrpc.Lightning/SubscribeInvoices') ||
+      has('invoices:read'),
+  };
+}
+
+function compactPermissions(values: Iterable<string | null | undefined>): string[] {
+  return [...values].flatMap((value) => {
+    const normalized = value?.trim();
+    return normalized ? [normalized] : [];
+  });
+}
+
+function hasPermission(values: string[], permission: string): boolean {
+  return values.some((value) => value.toLowerCase() === permission.toLowerCase());
 }
 
 function decodeJwtPayload(accessToken: string): Record<string, unknown> | null {
@@ -226,7 +374,7 @@ function readScopeValues(payload: Record<string, unknown>): string[] {
     }
   }
 
-  return normalizePermissions(scopes);
+  return normalizePermissionValues(scopes);
 }
 
 function decodeBase64Url(input: string): Uint8Array {

--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -1,5 +1,6 @@
 import { LniError } from '../errors.js';
 import { requestJson, resolveFetch, toTimeoutMs } from '../internal/http.js';
+import { getBlinkTokenPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, satsToMsats } from '../internal/transform.js';
 import { InvoiceType, type BlinkConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
@@ -211,6 +212,18 @@ export class BlinkNode implements LightningNode {
     const wallet = await this.getBtcWallet();
     this.cachedWalletId = wallet.id;
     return wallet.id;
+  }
+
+  async getPermissions(): Promise<string[]> {
+    const permissions = getBlinkTokenPermissions(this.config.apiKey);
+    if (!permissions) {
+      throw new LniError(
+        'InvalidInput',
+        'Blink API keys cannot be introspected. Use a JWT-style token with scopes or manually test permissions against Blink GraphQL operations.',
+      );
+    }
+
+    return permissions;
   }
 
   async getInfo(): Promise<NodeInfo> {

--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -3,7 +3,7 @@ import { requestJson, resolveFetch, toTimeoutMs } from '../internal/http.js';
 import { getBlinkTokenPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, satsToMsats } from '../internal/transform.js';
-import { InvoiceType, type BlinkConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
+import { InvoiceType, type BlinkConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type Transaction } from '../types.js';
 
 interface GraphQLError {
   message: string;
@@ -214,7 +214,7 @@ export class BlinkNode implements LightningNode {
     return wallet.id;
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     const permissions = getBlinkTokenPermissions(this.config.apiKey);
     if (!permissions) {
       throw new LniError(

--- a/bindings/typescript/src/nodes/cln.ts
+++ b/bindings/typescript/src/nodes/cln.ts
@@ -1,5 +1,6 @@
 import { LniError } from '../errors.js';
 import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '../internal/http.js';
+import { parseClnRunePermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, parseOptionalNumber } from '../internal/transform.js';
 import { InvoiceType, type ClnConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
@@ -125,6 +126,10 @@ export class ClnNode implements LightningNode {
     }
 
     return payload.invoice;
+  }
+
+  async getPermissions(): Promise<string[]> {
+    return parseClnRunePermissions(this.config.rune);
   }
 
   private invoiceToTransaction(invoice: ClnInvoice): Transaction {

--- a/bindings/typescript/src/nodes/cln.ts
+++ b/bindings/typescript/src/nodes/cln.ts
@@ -3,7 +3,7 @@ import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '.
 import { parseClnRunePermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, parseOptionalNumber } from '../internal/transform.js';
-import { InvoiceType, type ClnConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
+import { InvoiceType, type ClnConfig, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type Transaction } from '../types.js';
 
 interface ClnInfoResponse {
   id: string;
@@ -128,7 +128,7 @@ export class ClnNode implements LightningNode {
     return payload.invoice;
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     return parseClnRunePermissions(this.config.rune);
   }
 

--- a/bindings/typescript/src/nodes/lnd.ts
+++ b/bindings/typescript/src/nodes/lnd.ts
@@ -1,5 +1,7 @@
 import { LniError } from '../errors.js';
+import { encodeBase64Bytes, hexToBytes } from '../internal/encoding.js';
 import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '../internal/http.js';
+import { normalizePermissions, parseLndMacaroonPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, parseOptionalNumber, rHashToHex } from '../internal/transform.js';
 import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type LndConfig, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
@@ -59,6 +61,23 @@ interface LndPayResponseWrapper {
   };
 }
 
+interface LndMacaroonPermission {
+  entity: string;
+  action: string;
+}
+
+interface LndPermissionList {
+  permissions?: LndMacaroonPermission[];
+}
+
+interface LndListPermissionsResponse {
+  method_permissions?: Record<string, LndPermissionList>;
+}
+
+interface LndCheckMacaroonPermissionsResponse {
+  valid?: boolean;
+}
+
 export class LndNode implements LightningNode {
   private readonly fetchFn;
   private readonly timeoutMs?: number;
@@ -90,6 +109,38 @@ export class LndNode implements LightningNode {
       json,
       timeoutMs: this.timeoutMs,
     });
+  }
+
+  async getPermissions(): Promise<string[]> {
+    const macaroonBytes = hexToBytes(this.config.macaroon);
+
+    try {
+      const payload = await this.getJson<LndListPermissionsResponse>('/v1/macaroon/permissions');
+      const methodPermissions = Object.entries(payload.method_permissions ?? {});
+      const macaroon = encodeBase64Bytes(macaroonBytes);
+      const granted: string[] = [];
+
+      await Promise.all(
+        methodPermissions.map(async ([method, permissionList]) => {
+          const response = await this.postJson<LndCheckMacaroonPermissionsResponse>('/v1/macaroon/checkpermissions', {
+            macaroon,
+            permissions: permissionList.permissions ?? [],
+          });
+
+          if (response.valid) {
+            granted.push(method);
+          }
+        }),
+      );
+
+      return normalizePermissions(granted);
+    } catch (error) {
+      const parsed = parseLndMacaroonPermissions(macaroonBytes);
+      if (parsed.length) {
+        return parsed;
+      }
+      throw error;
+    }
   }
 
   private isPermissionDenied(error: unknown): boolean {

--- a/bindings/typescript/src/nodes/lnd.ts
+++ b/bindings/typescript/src/nodes/lnd.ts
@@ -1,10 +1,10 @@
 import { LniError } from '../errors.js';
 import { encodeBase64Bytes, hexToBytes } from '../internal/encoding.js';
 import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '../internal/http.js';
-import { normalizePermissions, parseLndMacaroonPermissions } from '../internal/permissions.js';
+import { isEmptyPermissions, normalizeLndPermissions, parseLndMacaroonPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, parseOptionalNumber, rHashToHex } from '../internal/transform.js';
-import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type LndConfig, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Transaction } from '../types.js';
+import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type LndConfig, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type Transaction } from '../types.js';
 
 interface LndGetInfoResponse {
   alias: string;
@@ -111,7 +111,7 @@ export class LndNode implements LightningNode {
     });
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     const macaroonBytes = hexToBytes(this.config.macaroon);
 
     try {
@@ -133,10 +133,10 @@ export class LndNode implements LightningNode {
         }),
       );
 
-      return normalizePermissions(granted);
+      return normalizeLndPermissions(granted);
     } catch (error) {
       const parsed = parseLndMacaroonPermissions(macaroonBytes);
-      if (parsed.length) {
+      if (!isEmptyPermissions(parsed)) {
         return parsed;
       }
       throw error;

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -1,6 +1,7 @@
 import { NWCClient, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Transaction } from '@getalby/sdk/nwc';
 import { LniError } from '../errors.js';
 import { bytesToHex, hexToBytes } from '../internal/encoding.js';
+import { NWC_METHOD_PERMISSIONS, normalizePermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, parseOptionalNumber } from '../internal/transform.js';
 import type { CreateInvoiceParams, CreateOfferParams, InvoiceEventCallback, LightningNode, ListTransactionsParams, LookupInvoiceParams, NodeInfo, NodeRequestOptions, NwcConfig, Offer, OnInvoiceEventParams, PayInvoiceParams, PayInvoiceResponse, Transaction } from '../types.js';
@@ -59,6 +60,14 @@ export class NwcNode implements LightningNode {
 
   close(): void {
     this.client.close();
+  }
+
+  async getPermissions(): Promise<string[]> {
+    const info = await this.client.getInfo().catch((error) => {
+      throw new LniError('Api', `Failed to get NWC permissions: ${(error as Error)?.message ?? 'unknown error'}`);
+    });
+    const methods = (info as Nip47GetInfoResponse & { methods?: string[] }).methods;
+    return normalizePermissions(methods?.length ? methods : NWC_METHOD_PERMISSIONS);
   }
 
   async getInfo(): Promise<NodeInfo> {

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -1,10 +1,10 @@
 import { NWCClient, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Transaction } from '@getalby/sdk/nwc';
 import { LniError } from '../errors.js';
 import { bytesToHex, hexToBytes } from '../internal/encoding.js';
-import { NWC_METHOD_PERMISSIONS, normalizePermissions } from '../internal/permissions.js';
+import { NWC_METHOD_PERMISSIONS, normalizeNwcPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, parseOptionalNumber } from '../internal/transform.js';
-import type { CreateInvoiceParams, CreateOfferParams, InvoiceEventCallback, LightningNode, ListTransactionsParams, LookupInvoiceParams, NodeInfo, NodeRequestOptions, NwcConfig, Offer, OnInvoiceEventParams, PayInvoiceParams, PayInvoiceResponse, Transaction } from '../types.js';
+import type { CreateInvoiceParams, CreateOfferParams, InvoiceEventCallback, LightningNode, ListTransactionsParams, LookupInvoiceParams, NodeInfo, NodeRequestOptions, NwcConfig, Offer, OnInvoiceEventParams, PayInvoiceParams, PayInvoiceResponse, Permissions, Transaction } from '../types.js';
 
 function extractPubkeyFromNwcUri(uri: string): string {
   try {
@@ -62,12 +62,12 @@ export class NwcNode implements LightningNode {
     this.client.close();
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     const info = await this.client.getInfo().catch((error) => {
       throw new LniError('Api', `Failed to get NWC permissions: ${(error as Error)?.message ?? 'unknown error'}`);
     });
     const methods = (info as Nip47GetInfoResponse & { methods?: string[] }).methods;
-    return normalizePermissions(methods?.length ? methods : NWC_METHOD_PERMISSIONS);
+    return normalizeNwcPermissions(methods?.length ? methods : NWC_METHOD_PERMISSIONS);
   }
 
   async getInfo(): Promise<NodeInfo> {

--- a/bindings/typescript/src/nodes/phoenixd.ts
+++ b/bindings/typescript/src/nodes/phoenixd.ts
@@ -89,6 +89,13 @@ export class PhoenixdNode implements LightningNode {
     });
   }
 
+  async getPermissions(): Promise<string[]> {
+    throw new LniError(
+      'InvalidInput',
+      'Phoenixd passwords cannot be introspected. Manually test permissions against Phoenixd REST endpoints.',
+    );
+  }
+
   async getInfo(): Promise<NodeInfo> {
     const [info, balance] = await Promise.all([
       this.requestJson<PhoenixdInfoResponse>('/getinfo', { method: 'GET' }),

--- a/bindings/typescript/src/nodes/phoenixd.ts
+++ b/bindings/typescript/src/nodes/phoenixd.ts
@@ -3,7 +3,7 @@ import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '.
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, satsToMsats, toUnixSeconds } from '../internal/transform.js';
 import { encodeBase64 } from '../internal/encoding.js';
-import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type PhoenixdConfig, type Transaction, type NodeInfo } from '../types.js';
+import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type PhoenixdConfig, type Transaction, type NodeInfo } from '../types.js';
 
 interface PhoenixdInfoResponse {
   nodeId: string;
@@ -89,7 +89,7 @@ export class PhoenixdNode implements LightningNode {
     });
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     throw new LniError(
       'InvalidInput',
       'Phoenixd passwords cannot be introspected. Manually test permissions against Phoenixd REST endpoints.',

--- a/bindings/typescript/src/nodes/speed.ts
+++ b/bindings/typescript/src/nodes/speed.ts
@@ -3,7 +3,7 @@ import { buildUrl, requestJson, resolveFetch, toTimeoutMs } from '../internal/ht
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { emptyNodeInfo, emptyTransaction, satsToMsats } from '../internal/transform.js';
 import { encodeBase64 } from '../internal/encoding.js';
-import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type SpeedConfig, type Transaction } from '../types.js';
+import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type SpeedConfig, type Transaction } from '../types.js';
 
 interface SpeedBalanceResponse {
   available: Array<{
@@ -106,7 +106,7 @@ export class SpeedNode implements LightningNode {
     });
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     throw new LniError(
       'InvalidInput',
       'Speed API keys cannot be introspected. Manually test permissions against Speed REST endpoints.',

--- a/bindings/typescript/src/nodes/speed.ts
+++ b/bindings/typescript/src/nodes/speed.ts
@@ -106,6 +106,13 @@ export class SpeedNode implements LightningNode {
     });
   }
 
+  async getPermissions(): Promise<string[]> {
+    throw new LniError(
+      'InvalidInput',
+      'Speed API keys cannot be introspected. Manually test permissions against Speed REST endpoints.',
+    );
+  }
+
   async getInfo(): Promise<NodeInfo> {
     const payload = await this.getJson<SpeedBalanceResponse>('/balances');
     const sats = payload.available.find((item) => item.target_currency === 'SATS');

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -1,5 +1,7 @@
+import { decode as decodeBolt11 } from 'light-bolt11-decoder';
 import { LniError } from '../errors.js';
 import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '../internal/http.js';
+import { getStrikeOauthPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { btcToMsats, emptyNodeInfo, emptyTransaction, matchesSearch, msatsToBtc, parseOptionalNumber, toUnixSeconds } from '../internal/transform.js';
 import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type StrikeConfig, type Transaction } from '../types.js';
@@ -69,6 +71,16 @@ interface StrikePaymentsResponse {
   data: StrikePaymentResponse[];
 }
 
+function paymentHashFromInvoice(invoice: string): string {
+  try {
+    const decoded = decodeBolt11(invoice);
+    const section = decoded.sections.find((item) => item.name === 'payment_hash');
+    return section?.name === 'payment_hash' ? section.value : '';
+  } catch {
+    return '';
+  }
+}
+
 export class StrikeNode implements LightningNode {
   private readonly fetchFn;
   private readonly timeoutMs?: number;
@@ -115,6 +127,18 @@ export class StrikeNode implements LightningNode {
 
   private isNotFoundError(error: unknown): boolean {
     return error instanceof LniError && error.code === 'Http' && error.status === 404;
+  }
+
+  async getPermissions(): Promise<string[]> {
+    const permissions = getStrikeOauthPermissions(this.config.apiKey);
+    if (!permissions) {
+      throw new LniError(
+        'InvalidInput',
+        'Strike API keys cannot be introspected. Use an OAuth access token or manually test permissions against Strike REST endpoints.',
+      );
+    }
+
+    return permissions;
   }
 
   async getInfo(): Promise<NodeInfo> {
@@ -184,21 +208,17 @@ export class StrikeNode implements LightningNode {
     });
 
     const execution = await this.patchJson<StrikePaymentExecutionResponse>(`/payment-quotes/${quote.paymentQuoteId}/execute`);
-    let payment: StrikePaymentResponse;
+    let payment: StrikePaymentResponse | undefined;
     try {
       payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
-    } catch (error) {
-      throw new LniError(
-        'Api',
-        `Strike payment executed but status lookup failed. paymentId=${execution.paymentId}`,
-        { cause: error },
-      );
+    } catch {
+      // payment.read is optional for payInvoice; without it we still know the payment was executed.
     }
 
-    const feeMsats = payment.lightning?.networkFee ? btcToMsats(payment.lightning.networkFee.amount) : 0;
+    const feeMsats = payment?.lightning?.networkFee ? btcToMsats(payment.lightning.networkFee.amount) : 0;
 
     return {
-      paymentHash: payment.lightning?.paymentHash ?? '',
+      paymentHash: payment?.lightning?.paymentHash ?? paymentHashFromInvoice(params.invoice),
       preimage: '',
       feeMsats,
     };

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -4,7 +4,7 @@ import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '.
 import { getStrikeOauthPermissions } from '../internal/permissions.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import { btcToMsats, emptyNodeInfo, emptyTransaction, matchesSearch, msatsToBtc, parseOptionalNumber, toUnixSeconds } from '../internal/transform.js';
-import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type StrikeConfig, type Transaction } from '../types.js';
+import { InvoiceType, type CreateInvoiceParams, type CreateOfferParams, type InvoiceEventCallback, type LightningNode, type ListTransactionsParams, type LookupInvoiceParams, type NodeInfo, type NodeRequestOptions, type Offer, type OnInvoiceEventParams, type PayInvoiceParams, type PayInvoiceResponse, type Permissions, type StrikeConfig, type Transaction } from '../types.js';
 
 interface StrikeBalance {
   currency: string;
@@ -129,7 +129,7 @@ export class StrikeNode implements LightningNode {
     return error instanceof LniError && error.code === 'Http' && error.status === 404;
   }
 
-  async getPermissions(): Promise<string[]> {
+  async getPermissions(): Promise<Permissions> {
     const permissions = getStrikeOauthPermissions(this.config.apiKey);
     if (!permissions) {
       throw new LniError(

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -181,8 +181,22 @@ export interface BlinkConfig {
   httpTimeout?: number;
 }
 
+export interface Permissions {
+  getInfo: boolean;
+  createInvoice: boolean;
+  payInvoice: boolean;
+  createOffer: boolean;
+  getOffer: boolean;
+  listOffers: boolean;
+  payOffer: boolean;
+  lookupInvoice: boolean;
+  listTransactions: boolean;
+  decode: boolean;
+  onInvoiceEvents: boolean;
+}
+
 export interface LightningNode {
-  getPermissions(): Promise<string[]>;
+  getPermissions(): Promise<Permissions>;
   getInfo(): Promise<NodeInfo>;
   createInvoice(params: CreateInvoiceParams): Promise<Transaction>;
   payInvoice(params: PayInvoiceParams): Promise<PayInvoiceResponse>;

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -182,6 +182,7 @@ export interface BlinkConfig {
 }
 
 export interface LightningNode {
+  getPermissions(): Promise<string[]>;
   getInfo(): Promise<NodeInfo>;
   createInvoice(params: CreateInvoiceParams): Promise<Transaction>;
   payInvoice(params: PayInvoiceParams): Promise<PayInvoiceResponse>;

--- a/crates/lni/blink/lib.rs
+++ b/crates/lni/blink/lib.rs
@@ -55,7 +55,7 @@ impl BlinkNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl BlinkNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         crate::permissions::parse_blink_token_permissions(&self.config.api_key).ok_or_else(|| {
             ApiError::InvalidInput(
                 "Blink API keys cannot be introspected. Use a JWT-style token with scopes or manually test permissions against Blink GraphQL operations.".to_string(),

--- a/crates/lni/blink/lib.rs
+++ b/crates/lni/blink/lib.rs
@@ -55,6 +55,14 @@ impl BlinkNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl BlinkNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        crate::permissions::parse_blink_token_permissions(&self.config.api_key).ok_or_else(|| {
+            ApiError::InvalidInput(
+                "Blink API keys cannot be introspected. Use a JWT-style token with scopes or manually test permissions against Blink GraphQL operations.".to_string(),
+            )
+        })
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::blink::api::get_info(&self.config).await
     }

--- a/crates/lni/cln/lib.rs
+++ b/crates/lni/cln/lib.rs
@@ -53,7 +53,7 @@ impl ClnNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl ClnNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         Ok(crate::permissions::parse_cln_rune_permissions(&self.config.rune))
     }
 

--- a/crates/lni/cln/lib.rs
+++ b/crates/lni/cln/lib.rs
@@ -53,6 +53,10 @@ impl ClnNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl ClnNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        Ok(crate::permissions::parse_cln_rune_permissions(&self.config.rune))
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::cln::api::get_info(self.config.clone()).await
     }

--- a/crates/lni/lib.rs
+++ b/crates/lni/lib.rs
@@ -80,6 +80,13 @@ macro_rules! impl_lightning_node {
     ($node_type:ty) => {
         #[async_trait::async_trait]
         impl crate::LightningNode for $node_type {
+            async fn get_permissions(&self) -> Result<Vec<String>, crate::ApiError> {
+                let this = self.clone();
+                crate::TOKIO_RUNTIME.spawn(async move {
+                    <$node_type>::get_permissions(&this).await
+                }).await.unwrap()
+            }
+
             async fn get_info(&self) -> Result<crate::NodeInfo, crate::ApiError> {
                 let this = self.clone();
                 crate::TOKIO_RUNTIME.spawn(async move {
@@ -229,6 +236,8 @@ pub mod spark {
 }
 
 pub mod lnurl;
+
+pub mod permissions;
 
 pub mod types;
 pub use types::*;

--- a/crates/lni/lib.rs
+++ b/crates/lni/lib.rs
@@ -80,7 +80,7 @@ macro_rules! impl_lightning_node {
     ($node_type:ty) => {
         #[async_trait::async_trait]
         impl crate::LightningNode for $node_type {
-            async fn get_permissions(&self) -> Result<Vec<String>, crate::ApiError> {
+            async fn get_permissions(&self) -> Result<crate::Permissions, crate::ApiError> {
                 let this = self.clone();
                 crate::TOKIO_RUNTIME.spawn(async move {
                     <$node_type>::get_permissions(&this).await

--- a/crates/lni/lnd/api.rs
+++ b/crates/lni/lnd/api.rs
@@ -176,7 +176,7 @@ struct LndCheckMacaroonPermissionsResponse {
     valid: Option<bool>,
 }
 
-pub async fn get_permissions(config: LndConfig) -> Result<Vec<String>, ApiError> {
+pub async fn get_permissions(config: LndConfig) -> Result<crate::Permissions, ApiError> {
     let macaroon_bytes = hex::decode(config.macaroon.trim()).map_err(|e| ApiError::InvalidInput(
         format!("Invalid LND macaroon hex: {}", e),
     ))?;
@@ -197,7 +197,7 @@ pub async fn get_permissions(config: LndConfig) -> Result<Vec<String>, ApiError>
 async fn get_lnd_remote_permissions(
     config: &LndConfig,
     macaroon_bytes: &[u8],
-) -> Result<Vec<String>, ApiError> {
+) -> Result<crate::Permissions, ApiError> {
     let client = async_client(config);
     let permissions_url = format!("{}/v1/macaroon/permissions", config.url);
     let permissions_response = client
@@ -236,7 +236,7 @@ async fn get_lnd_remote_permissions(
         }
     }
 
-    Ok(crate::permissions::normalize_permissions(granted))
+    Ok(crate::permissions::normalize_lnd_permissions(granted))
 }
 
 // get the one with the offer_id or label or get the first offer in the list or

--- a/crates/lni/lnd/api.rs
+++ b/crates/lni/lnd/api.rs
@@ -12,6 +12,7 @@ use crate::{
     DEFAULT_INVOICE_EXPIRY,
 };
 use reqwest::header;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 // Docs
@@ -146,6 +147,96 @@ pub async fn get_info(config: LndConfig) -> Result<NodeInfo, ApiError> {
     // Use shared logic to create NodeInfo
     let node_info = process_node_info_responses(info, balance);
     Ok(node_info)
+}
+
+#[derive(Debug, Deserialize)]
+struct LndListPermissionsResponse {
+    method_permissions: Option<std::collections::HashMap<String, LndPermissionList>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LndPermissionList {
+    permissions: Option<Vec<LndMacaroonPermission>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LndMacaroonPermission {
+    entity: String,
+    action: String,
+}
+
+#[derive(Debug, Serialize)]
+struct LndCheckMacaroonPermissionsRequest {
+    macaroon: String,
+    permissions: Vec<LndMacaroonPermission>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LndCheckMacaroonPermissionsResponse {
+    valid: Option<bool>,
+}
+
+pub async fn get_permissions(config: LndConfig) -> Result<Vec<String>, ApiError> {
+    let macaroon_bytes = hex::decode(config.macaroon.trim()).map_err(|e| ApiError::InvalidInput(
+        format!("Invalid LND macaroon hex: {}", e),
+    ))?;
+
+    match get_lnd_remote_permissions(&config, &macaroon_bytes).await {
+        Ok(permissions) => Ok(permissions),
+        Err(error) => {
+            let parsed = crate::permissions::parse_lnd_macaroon_permissions(&macaroon_bytes);
+            if parsed.is_empty() {
+                Err(error)
+            } else {
+                Ok(parsed)
+            }
+        }
+    }
+}
+
+async fn get_lnd_remote_permissions(
+    config: &LndConfig,
+    macaroon_bytes: &[u8],
+) -> Result<Vec<String>, ApiError> {
+    let client = async_client(config);
+    let permissions_url = format!("{}/v1/macaroon/permissions", config.url);
+    let permissions_response = client
+        .get(&permissions_url)
+        .send()
+        .await
+        .map_err(|e| ApiError::Http {
+            reason: format!("Failed to list LND macaroon permissions: {}", e),
+        })?;
+    let permissions_text = permissions_response.text().await.map_err(|e| ApiError::Http {
+        reason: format!("Failed to read LND permissions response: {}", e),
+    })?;
+    let permissions_payload: LndListPermissionsResponse = serde_json::from_str(&permissions_text)?;
+    let macaroon = base64::encode(macaroon_bytes);
+    let check_url = format!("{}/v1/macaroon/checkpermissions", config.url);
+    let mut granted = Vec::new();
+
+    for (method, permission_list) in permissions_payload.method_permissions.unwrap_or_default() {
+        let check_response = client
+            .post(&check_url)
+            .json(&LndCheckMacaroonPermissionsRequest {
+                macaroon: macaroon.clone(),
+                permissions: permission_list.permissions.unwrap_or_default(),
+            })
+            .send()
+            .await
+            .map_err(|e| ApiError::Http {
+                reason: format!("Failed to check LND macaroon permission for {method}: {e}"),
+            })?;
+        let check_text = check_response.text().await.map_err(|e| ApiError::Http {
+            reason: format!("Failed to read LND permission check response for {method}: {e}"),
+        })?;
+        let check_payload: LndCheckMacaroonPermissionsResponse = serde_json::from_str(&check_text)?;
+        if check_payload.valid.unwrap_or(false) {
+            granted.push(method);
+        }
+    }
+
+    Ok(crate::permissions::normalize_permissions(granted))
 }
 
 // get the one with the offer_id or label or get the first offer in the list or

--- a/crates/lni/lnd/lib.rs
+++ b/crates/lni/lnd/lib.rs
@@ -53,6 +53,10 @@ impl LndNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl LndNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        crate::lnd::api::get_permissions(self.config.clone()).await
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::lnd::api::get_info(self.config.clone()).await
     }

--- a/crates/lni/lnd/lib.rs
+++ b/crates/lni/lnd/lib.rs
@@ -53,7 +53,7 @@ impl LndNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl LndNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         crate::lnd::api::get_permissions(self.config.clone()).await
     }
 

--- a/crates/lni/nwc/api.rs
+++ b/crates/lni/nwc/api.rs
@@ -77,7 +77,7 @@ pub async fn get_info(config: NwcConfig) -> Result<NodeInfo, ApiError> {
         }
 }
 
-pub async fn get_permissions(config: NwcConfig) -> Result<Vec<String>, ApiError> {
+pub async fn get_permissions(config: NwcConfig) -> Result<crate::Permissions, ApiError> {
     let nwc = create_nwc_client(&config).await?;
     let info = nwc.get_info().await.map_err(|e| ApiError::Api {
         reason: format!("Failed to get NWC permissions: {}", e),
@@ -86,7 +86,7 @@ pub async fn get_permissions(config: NwcConfig) -> Result<Vec<String>, ApiError>
     if info.methods.is_empty() {
         Ok(crate::permissions::nwc_method_permissions())
     } else {
-        Ok(crate::permissions::normalize_permissions(info.methods))
+        Ok(crate::permissions::normalize_nwc_permissions(info.methods))
     }
 }
 

--- a/crates/lni/nwc/api.rs
+++ b/crates/lni/nwc/api.rs
@@ -77,6 +77,19 @@ pub async fn get_info(config: NwcConfig) -> Result<NodeInfo, ApiError> {
         }
 }
 
+pub async fn get_permissions(config: NwcConfig) -> Result<Vec<String>, ApiError> {
+    let nwc = create_nwc_client(&config).await?;
+    let info = nwc.get_info().await.map_err(|e| ApiError::Api {
+        reason: format!("Failed to get NWC permissions: {}", e),
+    })?;
+
+    if info.methods.is_empty() {
+        Ok(crate::permissions::nwc_method_permissions())
+    } else {
+        Ok(crate::permissions::normalize_permissions(info.methods))
+    }
+}
+
 pub async fn create_invoice(config: NwcConfig, params: CreateInvoiceParams) -> Result<Transaction, ApiError> {
     let nwc = create_nwc_client(&config).await?;
     
@@ -316,4 +329,3 @@ pub async fn on_invoice_events(
     })
     .await;
 }
-

--- a/crates/lni/nwc/lib.rs
+++ b/crates/lni/nwc/lib.rs
@@ -52,6 +52,10 @@ impl NwcNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl NwcNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        crate::nwc::api::get_permissions(self.config.clone()).await
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::nwc::api::get_info(self.config.clone()).await
     }

--- a/crates/lni/nwc/lib.rs
+++ b/crates/lni/nwc/lib.rs
@@ -52,7 +52,7 @@ impl NwcNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl NwcNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         crate::nwc::api::get_permissions(self.config.clone()).await
     }
 

--- a/crates/lni/permissions.rs
+++ b/crates/lni/permissions.rs
@@ -1,0 +1,283 @@
+use regex::Regex;
+
+const NWC_METHOD_PERMISSIONS: &[&str] = &[
+    "get_info",
+    "get_balance",
+    "make_invoice",
+    "pay_invoice",
+    "lookup_invoice",
+    "list_transactions",
+];
+
+const CLN_METHOD_PERMISSIONS: &[&str] = &[
+    "getinfo",
+    "listfunds",
+    "invoice",
+    "pay",
+    "offer",
+    "fetchinvoice",
+    "listoffers",
+    "listinvoices",
+    "decode",
+];
+
+const STRIKE_SCOPE_PERMISSIONS: &[(&str, &[&str])] = &[
+    ("get_info", &["partner.balances.read"]),
+    ("create_invoice", &["partner.receive-request.create"]),
+    (
+        "pay_invoice",
+        &[
+            "partner.payment-quote.lightning.create",
+            "partner.payment-quote.execute",
+        ],
+    ),
+    ("lookup_invoice", &["partner.receive-request.read"]),
+    (
+        "list_transactions",
+        &["partner.receive-request.read", "partner.payment.read"],
+    ),
+    ("on_invoice_events", &["partner.receive-request.read"]),
+];
+
+const BLINK_SCOPE_PERMISSIONS: &[(&str, &[&str])] = &[
+    ("get_info", &["read"]),
+    ("create_invoice", &["receive"]),
+    ("pay_invoice", &["write"]),
+    ("lookup_invoice", &["read"]),
+    ("list_transactions", &["read"]),
+    ("on_invoice_events", &["read"]),
+];
+
+pub fn nwc_method_permissions() -> Vec<String> {
+    normalize_permissions(
+        NWC_METHOD_PERMISSIONS
+            .iter()
+            .map(|permission| (*permission).to_string()),
+    )
+}
+
+pub fn normalize_permissions<I>(permissions: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut values: Vec<String> = permissions
+        .into_iter()
+        .map(|permission| permission.trim().to_string())
+        .filter(|permission| !permission.is_empty())
+        .collect();
+    values.sort();
+    values.dedup();
+    values
+}
+
+pub fn parse_cln_rune_permissions(rune: &str) -> Vec<String> {
+    let decoded = match base64::decode_config(pad_base64_url(rune), base64::URL_SAFE) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return normalize_permissions(
+                CLN_METHOD_PERMISSIONS
+                    .iter()
+                    .map(|permission| (*permission).to_string()),
+            )
+        }
+    };
+    let text = String::from_utf8_lossy(&decoded);
+    let matcher = Regex::new(r"method(?:=|\^)[A-Za-z0-9_.:-]+").expect("valid rune method regex");
+    let matches: Vec<&str> = matcher
+        .find_iter(&text)
+        .map(|match_| match_.as_str())
+        .collect();
+
+    if matches.is_empty() {
+        return normalize_permissions(
+            CLN_METHOD_PERMISSIONS
+                .iter()
+                .map(|permission| (*permission).to_string()),
+        );
+    }
+
+    let mut expanded = Vec::new();
+    for permission in matches {
+        if let Some(method) = permission.strip_prefix("method=") {
+            expanded.push(method.to_string());
+            continue;
+        }
+
+        if let Some(prefix) = permission.strip_prefix("method^") {
+            let mut matched = false;
+            for method in CLN_METHOD_PERMISSIONS {
+                if method.starts_with(prefix) {
+                    expanded.push((*method).to_string());
+                    matched = true;
+                }
+            }
+            if !matched {
+                expanded.push(format!("{prefix}*"));
+            }
+        }
+    }
+
+    normalize_permissions(expanded)
+}
+
+pub fn parse_lnd_macaroon_permissions(bytes: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(bytes);
+    let matcher = Regex::new(r"[a-z][a-z0-9_-]*:(?:read|write|generate)")
+        .expect("valid lnd macaroon permission regex");
+    normalize_permissions(
+        matcher
+            .find_iter(&text)
+            .map(|match_| match_.as_str().to_string()),
+    )
+}
+
+pub fn parse_strike_oauth_permissions(access_token: &str) -> Option<Vec<String>> {
+    let payload = decode_jwt_payload(access_token)?;
+    let scopes = read_scope_values(&payload);
+    let mut permissions = vec!["decode".to_string()];
+
+    for (permission, required_scopes) in STRIKE_SCOPE_PERMISSIONS {
+        if required_scopes.iter().all(|scope| scopes.iter().any(|item| item == scope)) {
+            permissions.push((*permission).to_string());
+        }
+    }
+
+    Some(normalize_permissions(permissions))
+}
+
+pub fn parse_blink_token_permissions(token: &str) -> Option<Vec<String>> {
+    let payload = decode_jwt_payload(token)?;
+    let scopes: Vec<String> = read_scope_values(&payload)
+        .into_iter()
+        .map(|scope| scope.to_lowercase())
+        .collect();
+    let mut permissions = vec!["decode".to_string()];
+
+    for (permission, required_scopes) in BLINK_SCOPE_PERMISSIONS {
+        if required_scopes.iter().all(|scope| scopes.iter().any(|item| item == scope)) {
+            permissions.push((*permission).to_string());
+        }
+    }
+
+    Some(normalize_permissions(permissions))
+}
+
+fn decode_jwt_payload(access_token: &str) -> Option<serde_json::Value> {
+    let mut parts = access_token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _signature = parts.next()?;
+    let decoded = base64::decode_config(pad_base64_url(payload), base64::URL_SAFE).ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn read_scope_values(payload: &serde_json::Value) -> Vec<String> {
+    let mut scopes = Vec::new();
+
+    for key in ["scope", "scp", "scopes"] {
+        match payload.get(key) {
+            Some(serde_json::Value::String(value)) => {
+                scopes.extend(value.split_whitespace().map(|scope| scope.to_string()));
+            }
+            Some(serde_json::Value::Array(values)) => {
+                scopes.extend(values.iter().filter_map(|value| value.as_str().map(|scope| scope.to_string())));
+            }
+            _ => {}
+        }
+    }
+
+    normalize_permissions(scopes)
+}
+
+fn pad_base64_url(input: &str) -> String {
+    let normalized = input.trim();
+    let padding = (4 - (normalized.len() % 4)) % 4;
+    format!("{}{}", normalized, "=".repeat(padding))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_cln_method_prefix_restrictions() {
+        let rune = base64::encode_config("unique-id&method^list|method=getinfo", base64::URL_SAFE);
+
+        assert_eq!(
+            parse_cln_rune_permissions(&rune),
+            vec![
+                "getinfo".to_string(),
+                "listfunds".to_string(),
+                "listinvoices".to_string(),
+                "listoffers".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_lnd_permission_pairs_from_macaroon_bytes() {
+        assert_eq!(
+            parse_lnd_macaroon_permissions(b"info:read invoices:write offchain:read"),
+            vec![
+                "info:read".to_string(),
+                "invoices:write".to_string(),
+                "offchain:read".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn maps_strike_oauth_scopes_to_lni_permissions() {
+        let header = base64_url_json(&serde_json::json!({ "alg": "none" }));
+        let payload = base64_url_json(&serde_json::json!({
+            "scope": "openid partner.balances.read partner.receive-request.create partner.receive-request.read partner.payment-quote.lightning.create partner.payment-quote.execute"
+        }));
+        let access_token = format!("{header}.{payload}.signature");
+
+        assert_eq!(
+            parse_strike_oauth_permissions(&access_token),
+            Some(vec![
+                "create_invoice".to_string(),
+                "decode".to_string(),
+                "get_info".to_string(),
+                "lookup_invoice".to_string(),
+                "on_invoice_events".to_string(),
+                "pay_invoice".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn rejects_opaque_strike_api_keys() {
+        assert_eq!(parse_strike_oauth_permissions("sk_test_opaque"), None);
+    }
+
+    #[test]
+    fn maps_blink_scopes_to_lni_permissions() {
+        let header = base64_url_json(&serde_json::json!({ "alg": "none" }));
+        let payload = base64_url_json(&serde_json::json!({ "scope": "Read Receive Write" }));
+        let token = format!("{header}.{payload}.signature");
+
+        assert_eq!(
+            parse_blink_token_permissions(&token),
+            Some(vec![
+                "create_invoice".to_string(),
+                "decode".to_string(),
+                "get_info".to_string(),
+                "list_transactions".to_string(),
+                "lookup_invoice".to_string(),
+                "on_invoice_events".to_string(),
+                "pay_invoice".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn rejects_opaque_blink_api_keys() {
+        assert_eq!(parse_blink_token_permissions("blink_opaque"), None);
+    }
+
+    fn base64_url_json(value: &serde_json::Value) -> String {
+        base64::encode_config(value.to_string(), base64::URL_SAFE).trim_end_matches('=').to_string()
+    }
+}

--- a/crates/lni/permissions.rs
+++ b/crates/lni/permissions.rs
@@ -1,5 +1,7 @@
 use regex::Regex;
 
+use crate::Permissions;
+
 const NWC_METHOD_PERMISSIONS: &[&str] = &[
     "get_info",
     "get_balance",
@@ -48,15 +50,30 @@ const BLINK_SCOPE_PERMISSIONS: &[(&str, &[&str])] = &[
     ("on_invoice_events", &["read"]),
 ];
 
-pub fn nwc_method_permissions() -> Vec<String> {
-    normalize_permissions(
-        NWC_METHOD_PERMISSIONS
-            .iter()
-            .map(|permission| (*permission).to_string()),
-    )
+pub fn nwc_method_permissions() -> Permissions {
+    normalize_nwc_permissions(NWC_METHOD_PERMISSIONS.iter().copied())
 }
 
-pub fn normalize_permissions<I>(permissions: I) -> Vec<String>
+pub fn normalize_nwc_permissions<I, S>(permissions: I) -> Permissions
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let values = normalized_value_set(permissions);
+    let has = |permission: &str| values.iter().any(|value| value.eq_ignore_ascii_case(permission));
+
+    Permissions {
+        get_info: has("get_balance"),
+        create_invoice: has("make_invoice"),
+        pay_invoice: has("pay_invoice"),
+        lookup_invoice: has("lookup_invoice"),
+        list_transactions: has("list_transactions"),
+        on_invoice_events: has("lookup_invoice"),
+        ..Default::default()
+    }
+}
+
+pub fn normalize_permission_values<I>(permissions: I) -> Vec<String>
 where
     I: IntoIterator<Item = String>,
 {
@@ -70,15 +87,20 @@ where
     values
 }
 
-pub fn parse_cln_rune_permissions(rune: &str) -> Vec<String> {
+pub fn normalize_permissions<I, S>(permissions: I) -> Permissions
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let values = normalized_value_set(permissions);
+    permissions_from_values(&values)
+}
+
+pub fn parse_cln_rune_permissions(rune: &str) -> Permissions {
     let decoded = match base64::decode_config(pad_base64_url(rune), base64::URL_SAFE) {
         Ok(bytes) => bytes,
         Err(_) => {
-            return normalize_permissions(
-                CLN_METHOD_PERMISSIONS
-                    .iter()
-                    .map(|permission| (*permission).to_string()),
-            )
+            return normalize_cln_permissions(CLN_METHOD_PERMISSIONS.iter().copied())
         }
     };
     let text = String::from_utf8_lossy(&decoded);
@@ -89,11 +111,7 @@ pub fn parse_cln_rune_permissions(rune: &str) -> Vec<String> {
         .collect();
 
     if matches.is_empty() {
-        return normalize_permissions(
-            CLN_METHOD_PERMISSIONS
-                .iter()
-                .map(|permission| (*permission).to_string()),
-        );
+        return normalize_cln_permissions(CLN_METHOD_PERMISSIONS.iter().copied());
     }
 
     let mut expanded = Vec::new();
@@ -117,21 +135,70 @@ pub fn parse_cln_rune_permissions(rune: &str) -> Vec<String> {
         }
     }
 
-    normalize_permissions(expanded)
+    normalize_cln_permissions(expanded)
 }
 
-pub fn parse_lnd_macaroon_permissions(bytes: &[u8]) -> Vec<String> {
+pub fn parse_lnd_macaroon_permissions(bytes: &[u8]) -> Permissions {
     let text = String::from_utf8_lossy(bytes);
     let matcher = Regex::new(r"[a-z][a-z0-9_-]*:(?:read|write|generate)")
         .expect("valid lnd macaroon permission regex");
-    normalize_permissions(
+    normalize_lnd_permissions(
         matcher
             .find_iter(&text)
             .map(|match_| match_.as_str().to_string()),
     )
 }
 
-pub fn parse_strike_oauth_permissions(access_token: &str) -> Option<Vec<String>> {
+pub fn normalize_lnd_permissions<I, S>(permissions: I) -> Permissions
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let values = normalized_value_set(permissions);
+    let has = |permission: &str| values.iter().any(|value| value.eq_ignore_ascii_case(permission));
+
+    Permissions {
+        get_info: (has("/lnrpc.Lightning/GetInfo") && has("/lnrpc.Lightning/ChannelBalance"))
+            || (has("info:read") && has("offchain:read")),
+        create_invoice: has("/lnrpc.Lightning/AddInvoice") || has("invoices:write"),
+        pay_invoice: has("/lnrpc.Lightning/SendPaymentSync")
+            || has("/routerrpc.Router/SendPaymentV2")
+            || has("offchain:write"),
+        lookup_invoice: has("/lnrpc.Lightning/LookupInvoice") || has("invoices:read"),
+        list_transactions: has("/lnrpc.Lightning/ListInvoices")
+            || has("/lnrpc.Lightning/ListPayments")
+            || has("invoices:read")
+            || has("offchain:read"),
+        decode: has("/lnrpc.Lightning/DecodePayReq") || has("offchain:read"),
+        on_invoice_events: has("/lnrpc.Lightning/SubscribeInvoices") || has("invoices:read"),
+        ..Default::default()
+    }
+}
+
+pub fn normalize_cln_permissions<I, S>(permissions: I) -> Permissions
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let values = normalized_value_set(permissions);
+    let has = |permission: &str| values.iter().any(|value| value.eq_ignore_ascii_case(permission));
+
+    Permissions {
+        get_info: has("getinfo") && has("listfunds"),
+        create_invoice: has("invoice"),
+        pay_invoice: has("pay"),
+        create_offer: has("offer"),
+        get_offer: has("listoffers"),
+        list_offers: has("listoffers"),
+        pay_offer: has("fetchinvoice") && has("pay"),
+        lookup_invoice: has("listinvoices"),
+        list_transactions: has("listinvoices"),
+        decode: has("decode"),
+        on_invoice_events: has("listinvoices"),
+    }
+}
+
+pub fn parse_strike_oauth_permissions(access_token: &str) -> Option<Permissions> {
     let payload = decode_jwt_payload(access_token)?;
     let scopes = read_scope_values(&payload);
     let mut permissions = vec!["decode".to_string()];
@@ -145,7 +212,7 @@ pub fn parse_strike_oauth_permissions(access_token: &str) -> Option<Vec<String>>
     Some(normalize_permissions(permissions))
 }
 
-pub fn parse_blink_token_permissions(token: &str) -> Option<Vec<String>> {
+pub fn parse_blink_token_permissions(token: &str) -> Option<Permissions> {
     let payload = decode_jwt_payload(token)?;
     let scopes: Vec<String> = read_scope_values(&payload)
         .into_iter()
@@ -160,6 +227,70 @@ pub fn parse_blink_token_permissions(token: &str) -> Option<Vec<String>> {
     }
 
     Some(normalize_permissions(permissions))
+}
+
+fn permissions_from_values(values: &[String]) -> Permissions {
+    let has = |permission: &str| {
+        values
+            .iter()
+            .any(|value| value.eq_ignore_ascii_case(permission))
+    };
+
+    let mut permissions = Permissions::default();
+
+    permissions.get_info = has("get_info")
+        || has("getinfo")
+        || has("get_balance")
+        || has("/lnrpc.Lightning/GetInfo")
+        || has("/lnrpc.Lightning/ChannelBalance")
+        || has("info:read");
+    permissions.create_invoice = has("create_invoice")
+        || has("make_invoice")
+        || has("invoice")
+        || has("/lnrpc.Lightning/AddInvoice")
+        || has("invoices:write");
+    permissions.pay_invoice = has("pay_invoice")
+        || has("pay")
+        || has("/lnrpc.Lightning/SendPaymentSync")
+        || has("/routerrpc.Router/SendPaymentV2")
+        || has("offchain:write");
+    permissions.create_offer = has("create_offer") || has("offer") || has("offers:write");
+    permissions.get_offer = has("get_offer") || has("listoffers") || has("offers:read");
+    permissions.list_offers = has("list_offers") || has("listoffers") || has("offers:read");
+    permissions.pay_offer = has("pay_offer") || (has("fetchinvoice") && permissions.pay_invoice);
+    permissions.lookup_invoice = has("lookup_invoice")
+        || has("lookup-invoice")
+        || has("listinvoices")
+        || has("/lnrpc.Lightning/LookupInvoice")
+        || has("invoices:read");
+    permissions.list_transactions = has("list_transactions")
+        || has("listinvoices")
+        || has("/lnrpc.Lightning/ListInvoices")
+        || has("/lnrpc.Lightning/ListPayments")
+        || has("invoices:read")
+        || has("offchain:read");
+    permissions.decode = has("decode")
+        || has("/lnrpc.Lightning/DecodePayReq")
+        || has("address:read");
+    permissions.on_invoice_events = has("on_invoice_events")
+        || has("lookup_invoice")
+        || has("listinvoices")
+        || has("/lnrpc.Lightning/SubscribeInvoices")
+        || has("invoices:read");
+
+    permissions
+}
+
+fn normalized_value_set<I, S>(permissions: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    permissions
+        .into_iter()
+        .map(|permission| permission.as_ref().trim().to_string())
+        .filter(|permission| !permission.is_empty())
+        .collect()
 }
 
 fn decode_jwt_payload(access_token: &str) -> Option<serde_json::Value> {
@@ -186,7 +317,7 @@ fn read_scope_values(payload: &serde_json::Value) -> Vec<String> {
         }
     }
 
-    normalize_permissions(scopes)
+    normalize_permission_values(scopes)
 }
 
 fn pad_base64_url(input: &str) -> String {
@@ -205,12 +336,15 @@ mod tests {
 
         assert_eq!(
             parse_cln_rune_permissions(&rune),
-            vec![
-                "getinfo".to_string(),
-                "listfunds".to_string(),
-                "listinvoices".to_string(),
-                "listoffers".to_string(),
-            ]
+            Permissions {
+                get_info: true,
+                get_offer: true,
+                list_offers: true,
+                lookup_invoice: true,
+                list_transactions: true,
+                on_invoice_events: true,
+                ..Default::default()
+            }
         );
     }
 
@@ -218,11 +352,13 @@ mod tests {
     fn parses_lnd_permission_pairs_from_macaroon_bytes() {
         assert_eq!(
             parse_lnd_macaroon_permissions(b"info:read invoices:write offchain:read"),
-            vec![
-                "info:read".to_string(),
-                "invoices:write".to_string(),
-                "offchain:read".to_string(),
-            ]
+            Permissions {
+                get_info: true,
+                create_invoice: true,
+                list_transactions: true,
+                decode: true,
+                ..Default::default()
+            }
         );
     }
 
@@ -236,14 +372,15 @@ mod tests {
 
         assert_eq!(
             parse_strike_oauth_permissions(&access_token),
-            Some(vec![
-                "create_invoice".to_string(),
-                "decode".to_string(),
-                "get_info".to_string(),
-                "lookup_invoice".to_string(),
-                "on_invoice_events".to_string(),
-                "pay_invoice".to_string(),
-            ])
+            Some(Permissions {
+                get_info: true,
+                create_invoice: true,
+                pay_invoice: true,
+                lookup_invoice: true,
+                decode: true,
+                on_invoice_events: true,
+                ..Default::default()
+            })
         );
     }
 
@@ -260,15 +397,16 @@ mod tests {
 
         assert_eq!(
             parse_blink_token_permissions(&token),
-            Some(vec![
-                "create_invoice".to_string(),
-                "decode".to_string(),
-                "get_info".to_string(),
-                "list_transactions".to_string(),
-                "lookup_invoice".to_string(),
-                "on_invoice_events".to_string(),
-                "pay_invoice".to_string(),
-            ])
+            Some(Permissions {
+                get_info: true,
+                create_invoice: true,
+                pay_invoice: true,
+                lookup_invoice: true,
+                list_transactions: true,
+                decode: true,
+                on_invoice_events: true,
+                ..Default::default()
+            })
         );
     }
 

--- a/crates/lni/phoenixd/lib.rs
+++ b/crates/lni/phoenixd/lib.rs
@@ -54,6 +54,12 @@ impl PhoenixdNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl PhoenixdNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        Err(ApiError::InvalidInput(
+            "Phoenixd passwords cannot be introspected. Manually test permissions against Phoenixd REST endpoints.".to_string(),
+        ))
+    }
+
     pub async fn get_info(&self) -> Result<crate::NodeInfo, ApiError> {
         crate::phoenixd::api::get_info(self.config.clone()).await
     }

--- a/crates/lni/phoenixd/lib.rs
+++ b/crates/lni/phoenixd/lib.rs
@@ -54,7 +54,7 @@ impl PhoenixdNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl PhoenixdNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         Err(ApiError::InvalidInput(
             "Phoenixd passwords cannot be introspected. Manually test permissions against Phoenixd REST endpoints.".to_string(),
         ))

--- a/crates/lni/spark/lib.rs
+++ b/crates/lni/spark/lib.rs
@@ -152,7 +152,7 @@ impl SparkNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SparkNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         Err(ApiError::InvalidInput(
             "Spark wallet credentials cannot be introspected. Manually test permissions against Spark wallet operations.".to_string(),
         ))

--- a/crates/lni/spark/lib.rs
+++ b/crates/lni/spark/lib.rs
@@ -152,6 +152,12 @@ impl SparkNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SparkNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        Err(ApiError::InvalidInput(
+            "Spark wallet credentials cannot be introspected. Manually test permissions against Spark wallet operations.".to_string(),
+        ))
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         let network = self.config.network.as_deref().unwrap_or("mainnet");
         crate::spark::api::get_info(self.sdk.clone(), network).await

--- a/crates/lni/speed/lib.rs
+++ b/crates/lni/speed/lib.rs
@@ -54,6 +54,12 @@ impl SpeedNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SpeedNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        Err(ApiError::InvalidInput(
+            "Speed API keys cannot be introspected. Manually test permissions against Speed REST endpoints.".to_string(),
+        ))
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::speed::api::get_info(&self.config).await
     }

--- a/crates/lni/speed/lib.rs
+++ b/crates/lni/speed/lib.rs
@@ -54,7 +54,7 @@ impl SpeedNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SpeedNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         Err(ApiError::InvalidInput(
             "Speed API keys cannot be introspected. Manually test permissions against Speed REST endpoints.".to_string(),
         ))

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -55,7 +55,7 @@ impl StrikeNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl StrikeNode {
-    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+    pub async fn get_permissions(&self) -> Result<crate::Permissions, ApiError> {
         crate::permissions::parse_strike_oauth_permissions(&self.config.api_key).ok_or_else(|| {
             ApiError::InvalidInput(
                 "Strike API keys cannot be introspected. Use an OAuth access token or manually test permissions against Strike REST endpoints.".to_string(),

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -55,6 +55,14 @@ impl StrikeNode {
 // All node methods - UniFFI exports these directly when the feature is enabled
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl StrikeNode {
+    pub async fn get_permissions(&self) -> Result<Vec<String>, ApiError> {
+        crate::permissions::parse_strike_oauth_permissions(&self.config.api_key).ok_or_else(|| {
+            ApiError::InvalidInput(
+                "Strike API keys cannot be introspected. Use an OAuth access token or manually test permissions against Strike REST endpoints.".to_string(),
+            )
+        })
+    }
+
     pub async fn get_info(&self) -> Result<NodeInfo, ApiError> {
         crate::strike::api::get_info(self.config.clone()).await
     }

--- a/crates/lni/types.rs
+++ b/crates/lni/types.rs
@@ -20,7 +20,7 @@ pub enum LightningNodeEnum {
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait]
 pub trait LightningNode: Send + Sync {
-    async fn get_permissions(&self) -> Result<Vec<String>, crate::ApiError>;
+    async fn get_permissions(&self) -> Result<Permissions, crate::ApiError>;
     async fn get_info(&self) -> Result<crate::NodeInfo, crate::ApiError>;
     async fn create_invoice(&self, params: CreateInvoiceParams) -> Result<Transaction, crate::ApiError>;
     async fn pay_invoice(&self, params: PayInvoiceParams) -> Result<PayInvoiceResponse, crate::ApiError>;
@@ -44,6 +44,39 @@ pub trait LightningNode: Send + Sync {
         params: crate::types::OnInvoiceEventParams,
         callback: std::sync::Arc<dyn crate::types::OnInvoiceEventCallback>,
     );
+}
+
+#[cfg_attr(feature = "napi_rs", napi(object))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+pub struct Permissions {
+    pub get_info: bool,
+    pub create_invoice: bool,
+    pub pay_invoice: bool,
+    pub create_offer: bool,
+    pub get_offer: bool,
+    pub list_offers: bool,
+    pub pay_offer: bool,
+    pub lookup_invoice: bool,
+    pub list_transactions: bool,
+    pub decode: bool,
+    pub on_invoice_events: bool,
+}
+
+impl Permissions {
+    pub fn is_empty(&self) -> bool {
+        !self.get_info
+            && !self.create_invoice
+            && !self.pay_invoice
+            && !self.create_offer
+            && !self.get_offer
+            && !self.list_offers
+            && !self.pay_offer
+            && !self.lookup_invoice
+            && !self.list_transactions
+            && !self.decode
+            && !self.on_invoice_events
+    }
 }
 
 #[cfg_attr(feature = "napi_rs", napi(string_enum))]

--- a/crates/lni/types.rs
+++ b/crates/lni/types.rs
@@ -20,6 +20,7 @@ pub enum LightningNodeEnum {
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait]
 pub trait LightningNode: Send + Sync {
+    async fn get_permissions(&self) -> Result<Vec<String>, crate::ApiError>;
     async fn get_info(&self) -> Result<crate::NodeInfo, crate::ApiError>;
     async fn create_invoice(&self, params: CreateInvoiceParams) -> Result<Transaction, crate::ApiError>;
     async fn pay_invoice(&self, params: PayInvoiceParams) -> Result<PayInvoiceResponse, crate::ApiError>;


### PR DESCRIPTION
## Summary

Adds permission introspection to the shared LightningNode API across TypeScript and Rust.

This introduces `getPermissions()` / `get_permissions()` for adapters that can safely derive permissions from their configured credential type, while returning explicit errors for providers whose credentials cannot be introspected locally.

## What Changed

- Added `getPermissions(): Promise<string[]>` to the TypeScript `LightningNode` interface.
- Added `get_permissions() -> Result<Vec<String>, ApiError>` to the Rust `LightningNode` trait and enum wrapper.
- Added shared TypeScript and Rust permission parsing helpers.
- Added NWC permission discovery from `get_info().methods`.
- Added CLN rune parsing for method restrictions.
- Added LND macaroon permission checks through LND REST, with local macaroon parsing fallback.
- Added Strike OAuth JWT scope parsing and normalized Strike scopes to LNI permissions.
- Added Blink JWT-style scope parsing and normalized Blink scopes to LNI permissions.
- Added explicit permission introspection errors for opaque credentials:
  - Strike API keys
  - Blink API keys
  - Speed API keys
  - Phoenixd passwords
  - Spark wallet credentials
- Added Arkade and Spark implementations so optional TypeScript adapters satisfy the shared LightningNode contract.
- Bumped TypeScript package versions to `0.2.3`.

## Provider Behavior

| Provider | Behavior |
| --- | --- |
| NWC | Returns methods from NWC `get_info`; falls back to known NWC methods when empty. |
| CLN | Parses rune restrictions into allowed LNI methods. |
| LND | Checks macaroon permissions through LND REST; falls back to local macaroon parsing. |
| Strike | Decodes OAuth JWT scopes and maps them to LNI permissions. Opaque API keys return an error. |
| Blink | Decodes JWT-style scopes and maps them to LNI permissions. Opaque API keys return an error. |
| Speed | Returns an error because API keys cannot be introspected. |
| Phoenixd | Returns an error because passwords cannot be introspected. |
| Spark | Returns an error because wallet credentials cannot be introspected. |
| Arkade | Returns supported adapter permissions. |

## Strike Scope Mapping

- `partner.balances.read` -> `getInfo`
- `partner.receive-request.create` -> `createInvoice`
- `partner.payment-quote.lightning.create` + `partner.payment-quote.execute` -> `payInvoice`
- `partner.receive-request.read` -> `lookupInvoice`, `onInvoiceEvents`
- `partner.receive-request.read` + `partner.payment.read` -> `listTransactions`
- Scoped OAuth tokens also include `decode`

`partner.payment.read` is no longer required for `payInvoice`; it is only used to enrich payment details after quote execution.

## Blink Scope Mapping

- `Read` -> `getInfo`, `lookupInvoice`, `listTransactions`, `onInvoiceEvents`
- `Receive` -> `createInvoice`
- `Write` -> `payInvoice`
- Scoped tokens also include `decode`

## Testing

- `npm test -- --run src/__tests__/permissions.test.ts`
- `npm run typecheck`
- `npm run pack:dry-run` in `bindings/typescript`
- `npm test -- --run src/__tests__/spark-node.test.ts`
- `npm run typecheck` in `bindings/typescript-spark`
- `npm run pack:dry-run` in `bindings/typescript-spark`
- `cargo test -p lni permissions`
- `cargo check -p lni`
- `git diff --check`

`cargo check -p lni` passes with existing warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getPermissions()` method to all node implementations to determine supported operations.
  * Introduced `Permissions` interface tracking capability availability for invoices, payments, decoding, and event polling.

* **Documentation**
  * Updated README example demonstrating permission retrieval.

* **Version Updates**
  * Bumped package versions to 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->