### PR TITLE
nwc payment result fallback

### DIFF
--- a/bindings/typescript/src/__tests__/integration/nwc.real.test.ts
+++ b/bindings/typescript/src/__tests__/integration/nwc.real.test.ts
@@ -3,7 +3,7 @@ import { NwcNode } from '../../nodes/nwc.js';
 import { hasEnv, itIf, testInvoiceLabel, timeout } from './helpers.js';
 
 describe('Real integration from crates/lni/.env > NwcNode', async () => {
-  const enabled = hasEnv('NWC_URI');
+  const enabled = hasEnv('NWC_URI') && typeof globalThis.WebSocket === 'function';
 
   const makeNode = () => new NwcNode({ nwcUri: process.env.NWC_URI!, httpTimeout: 15 });
  
@@ -35,6 +35,44 @@ describe('Real integration from crates/lni/.env > NwcNode', async () => {
 
       const invoiceLookup = await node.lookupInvoice({ search: invoice.invoice });
       expect(typeof invoiceLookup.type).toBe('string');
+    } finally {
+      node.close();
+    }
+  }, timeout);
+
+  itIf(enabled)('payInvoice can be canceled against a real NWC connection', async () => {
+    const verificationNode = makeNode();
+    try {
+      const info = await verificationNode.getInfo();
+      expect(typeof info.alias).toBe('string');
+    } finally {
+      verificationNode.close();
+    }
+
+    const node = new NwcNode({ nwcUri: process.env.NWC_URI!, httpTimeout: 0.25 });
+    const controller = new AbortController();
+
+    try {
+      const startedAt = Date.now();
+      const payment = node.payInvoice(
+        {
+          invoice: 'lnbc1lniaborttest',
+        },
+        {
+          signal: controller.signal,
+        },
+      );
+
+      queueMicrotask(() => {
+        controller.abort();
+      });
+
+      await expect(payment).rejects.toMatchObject({
+        code: 'Canceled',
+      });
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
     } finally {
       node.close();
     }

--- a/bindings/typescript/src/__tests__/nwc.test.ts
+++ b/bindings/typescript/src/__tests__/nwc.test.ts
@@ -16,8 +16,18 @@ const nwcMocks = vi.hoisted(() => ({
   lookupInvoice: vi.fn(),
   listTransactions: vi.fn(),
   executeNip47Request: vi.fn(),
+  checkConnected: vi.fn(),
+  selectEncryptionType: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  signEvent: vi.fn(),
+  poolSubscribe: vi.fn(),
+  poolPublish: vi.fn(),
+  subscriptionClose: vi.fn(),
+  replyHandler: undefined as ((event: { id: string; content: string }) => void | Promise<void>) | undefined,
   close: vi.fn(),
   usePrivateExecute: false,
+  useCancelableRequest: false,
 }));
 
 const bolt11Mocks = vi.hoisted(() => ({
@@ -26,6 +36,12 @@ const bolt11Mocks = vi.hoisted(() => ({
 
 vi.mock('@getalby/sdk/nwc', () => ({
   Nip47Error: nwcMocks.Nip47Error,
+  Nip47PublishError: nwcMocks.Nip47Error,
+  Nip47PublishTimeoutError: nwcMocks.Nip47Error,
+  Nip47ReplyTimeoutError: nwcMocks.Nip47Error,
+  Nip47ResponseDecodingError: nwcMocks.Nip47Error,
+  Nip47ResponseValidationError: nwcMocks.Nip47Error,
+  Nip47WalletError: nwcMocks.Nip47Error,
   NWCClient: Object.assign(
     vi.fn().mockImplementation(() => {
       const client = {
@@ -42,6 +58,24 @@ vi.mock('@getalby/sdk/nwc', () => ({
         return {
           ...client,
           executeNip47Request: nwcMocks.executeNip47Request,
+        };
+      }
+
+      if (nwcMocks.useCancelableRequest) {
+        return {
+          ...client,
+          pool: {
+            subscribe: nwcMocks.poolSubscribe,
+            publish: nwcMocks.poolPublish,
+          },
+          relayUrls: ['wss://relay.example'],
+          walletPubkey: 'wallet-pubkey',
+          encryptionType: 'nip44_v2',
+          encrypt: nwcMocks.encrypt,
+          decrypt: nwcMocks.decrypt,
+          signEvent: nwcMocks.signEvent,
+          _checkConnected: nwcMocks.checkConnected,
+          _selectEncryptionType: nwcMocks.selectEncryptionType,
         };
       }
 
@@ -135,8 +169,36 @@ beforeEach(() => {
   nwcMocks.lookupInvoice.mockReset();
   nwcMocks.listTransactions.mockReset();
   nwcMocks.executeNip47Request.mockReset();
+  nwcMocks.checkConnected.mockReset();
+  nwcMocks.selectEncryptionType.mockReset();
+  nwcMocks.encrypt.mockReset();
+  nwcMocks.decrypt.mockReset();
+  nwcMocks.signEvent.mockReset();
+  nwcMocks.poolSubscribe.mockReset();
+  nwcMocks.poolPublish.mockReset();
+  nwcMocks.subscriptionClose.mockReset();
+  nwcMocks.replyHandler = undefined;
   nwcMocks.close.mockReset();
   nwcMocks.usePrivateExecute = false;
+  nwcMocks.useCancelableRequest = false;
+  nwcMocks.checkConnected.mockResolvedValue(undefined);
+  nwcMocks.selectEncryptionType.mockResolvedValue(undefined);
+  nwcMocks.encrypt.mockResolvedValue('encrypted-command');
+  nwcMocks.decrypt.mockResolvedValue(JSON.stringify({ result: { preimage: '', fees_paid: 21 } }));
+  nwcMocks.signEvent.mockResolvedValue({
+    id: 'request-event-id',
+    kind: 23194,
+    created_at: 1,
+    tags: [],
+    content: 'encrypted-command',
+  });
+  nwcMocks.poolSubscribe.mockImplementation((_relayUrls, _filters, params) => {
+    nwcMocks.replyHandler = params.onevent;
+    return {
+      close: nwcMocks.subscriptionClose,
+    };
+  });
+  nwcMocks.poolPublish.mockReturnValue([Promise.resolve(undefined)]);
   bolt11Mocks.decode.mockReset();
   mockBolt11Decode();
 });
@@ -154,6 +216,146 @@ afterEach(() => {
 });
 
 describe('NwcNode.payInvoice', () => {
+  it('resolves a normal NIP-47 response and clears the reply timeout', async () => {
+    vi.useFakeTimers();
+    nwcMocks.useCancelableRequest = true;
+
+    const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE });
+    await vi.advanceTimersByTimeAsync(0);
+    await nwcMocks.replyHandler?.({ id: 'reply-event-id', content: 'encrypted-response' });
+
+    await expect(response).resolves.toEqual({
+      paymentHash: '',
+      preimage: '',
+      feeMsats: 21,
+    });
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects on the NIP-47 reply timeout when no response or cancel happens', async () => {
+    vi.useFakeTimers();
+    nwcMocks.useCancelableRequest = true;
+
+    const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE });
+    const assertion = expect(response).rejects.toMatchObject({
+      name: 'NwcError',
+      code: 'NwcError',
+      nwcCode: 'INTERNAL',
+      operation: 'pay_invoice',
+      message: 'reply timeout: event request-event-id',
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await assertion;
+    const closeCount = nwcMocks.subscriptionClose.mock.calls.length;
+    expect(closeCount).toBeGreaterThanOrEqual(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(closeCount);
+  });
+
+  it('cancels an active NIP-47 request with AbortSignal and does not timeout later', async () => {
+    vi.useFakeTimers();
+    nwcMocks.useCancelableRequest = true;
+    const controller = new AbortController();
+
+    const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE }, { signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+
+    await expect(response).rejects.toMatchObject({
+      name: 'LniError',
+      code: 'Canceled',
+      message: 'Failed to pay invoice: NWC pay invoice canceled because the request was aborted.',
+    });
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels active NIP-47 requests on close and close is idempotent', async () => {
+    vi.useFakeTimers();
+    nwcMocks.useCancelableRequest = true;
+    const node = makeNode();
+
+    const response = node.payInvoice({ invoice: BOLT11_INVOICE });
+    await vi.advanceTimersByTimeAsync(0);
+    node.close();
+    node.close();
+
+    await expect(response).rejects.toMatchObject({
+      name: 'LniError',
+      code: 'Canceled',
+      message: 'Failed to pay invoice: NWC request canceled because the node was closed.',
+    });
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls lookup_invoice and returns the payment result when the pay_invoice reply is missing', async () => {
+    vi.useFakeTimers();
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockResolvedValue(
+      nwcTransaction({
+        type: 'outgoing',
+        preimage: ZERO_PREIMAGE,
+        fees_paid: 21,
+      }),
+    );
+
+    const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE });
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(response).resolves.toEqual({
+      paymentHash: ZERO_PREIMAGE_PAYMENT_HASH,
+      preimage: ZERO_PREIMAGE,
+      feeMsats: 21,
+    });
+    expect(nwcMocks.lookupInvoice).toHaveBeenCalledWith({
+      payment_hash: PAYMENT_HASH,
+      invoice: undefined,
+    });
+    expect(nwcMocks.close).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
+  });
+
+  it('keeps waiting when lookup polling finds no preimage and still rejects at the timeout', async () => {
+    vi.useFakeTimers();
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockResolvedValue(
+      nwcTransaction({
+        type: 'outgoing',
+        preimage: '',
+        settled_at: 150,
+      }),
+    );
+
+    const response = makeNodeWithTimeout(4).payInvoice({ invoice: BOLT11_INVOICE });
+    const assertion = expect(response).rejects.toMatchObject({
+      code: 'NetworkError',
+      message:
+        'Failed to pay invoice: NWC pay invoice timed out after 4s. Check that the relay websocket is reachable and the wallet connection still exists.',
+    });
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(nwcMocks.lookupInvoice).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await assertion;
+    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+  });
+
   it('passes httpTimeout to the SDK NIP-47 timeout values when the SDK request API is available', async () => {
     nwcMocks.usePrivateExecute = true;
     nwcMocks.executeNip47Request.mockResolvedValue({

--- a/bindings/typescript/src/__tests__/nwc.test.ts
+++ b/bindings/typescript/src/__tests__/nwc.test.ts
@@ -257,6 +257,30 @@ describe('NwcNode.payInvoice', () => {
     expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(closeCount);
   });
 
+  it('applies the NWC timeout to relay setup before subscribing for a response', async () => {
+    vi.useFakeTimers();
+    nwcMocks.useCancelableRequest = true;
+    nwcMocks.checkConnected.mockReturnValue(new Promise(() => undefined));
+
+    const response = makeNodeWithTimeout(0.001).payInvoice({ invoice: BOLT11_INVOICE });
+    const assertion = expect(response).rejects.toMatchObject({
+      name: 'NwcError',
+      code: 'NwcError',
+      nwcCode: 'INTERNAL',
+      operation: 'pay_invoice',
+      message: 'reply timeout: request setup for pay_invoice',
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    await assertion;
+    expect(nwcMocks.poolSubscribe).not.toHaveBeenCalled();
+    expect(nwcMocks.subscriptionClose).not.toHaveBeenCalled();
+    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+  });
+
   it('cancels an active NIP-47 request with AbortSignal and does not timeout later', async () => {
     vi.useFakeTimers();
     nwcMocks.useCancelableRequest = true;

--- a/bindings/typescript/src/__tests__/nwc.test.ts
+++ b/bindings/typescript/src/__tests__/nwc.test.ts
@@ -218,72 +218,73 @@ afterEach(() => {
 describe('NwcNode.payInvoice', () => {
   it('resolves a normal NIP-47 response and clears the reply timeout', async () => {
     vi.useFakeTimers();
-    nwcMocks.useCancelableRequest = true;
+    nwcMocks.payInvoice.mockResolvedValue({
+      preimage: '',
+      fees_paid: 21,
+    });
 
-    const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE });
-    await vi.advanceTimersByTimeAsync(0);
-    await nwcMocks.replyHandler?.({ id: 'reply-event-id', content: 'encrypted-response' });
+    const response = await makeNode().payInvoice({ invoice: BOLT11_INVOICE });
 
-    await expect(response).resolves.toEqual({
+    expect(response).toEqual({
       paymentHash: '',
       preimage: '',
       feeMsats: 21,
     });
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.payInvoice).toHaveBeenCalledWith({
+      invoice: BOLT11_INVOICE,
+      amount: undefined,
+    });
+    expect(nwcMocks.close).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
   it('rejects on the NIP-47 reply timeout when no response or cancel happens', async () => {
     vi.useFakeTimers();
-    nwcMocks.useCancelableRequest = true;
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockReturnValue(new Promise(() => undefined));
 
     const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE });
     const assertion = expect(response).rejects.toMatchObject({
-      name: 'NwcError',
-      code: 'NwcError',
-      nwcCode: 'INTERNAL',
-      operation: 'pay_invoice',
-      message: 'reply timeout: event request-event-id',
+      code: 'NetworkError',
+      message:
+        'Failed to pay invoice: NWC pay invoice timed out after 60s. Check that the relay websocket is reachable and the wallet connection still exists.',
     });
-    await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(60_000);
 
     await assertion;
-    const closeCount = nwcMocks.subscriptionClose.mock.calls.length;
-    expect(closeCount).toBeGreaterThanOrEqual(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(closeCount);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
-  it('applies the NWC timeout to relay setup before subscribing for a response', async () => {
+  it('applies the NWC timeout around the public SDK request without closing the shared client', async () => {
     vi.useFakeTimers();
-    nwcMocks.useCancelableRequest = true;
-    nwcMocks.checkConnected.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockReturnValue(new Promise(() => undefined));
 
     const response = makeNodeWithTimeout(0.001).payInvoice({ invoice: BOLT11_INVOICE });
     const assertion = expect(response).rejects.toMatchObject({
-      name: 'NwcError',
-      code: 'NwcError',
-      nwcCode: 'INTERNAL',
-      operation: 'pay_invoice',
-      message: 'reply timeout: request setup for pay_invoice',
+      code: 'NetworkError',
+      message:
+        'Failed to pay invoice: NWC pay invoice timed out after 0.001s. Check that the relay websocket is reachable and the wallet connection still exists.',
     });
     await vi.advanceTimersByTimeAsync(1);
 
     await assertion;
     expect(nwcMocks.poolSubscribe).not.toHaveBeenCalled();
     expect(nwcMocks.subscriptionClose).not.toHaveBeenCalled();
-    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
   it('cancels an active NIP-47 request with AbortSignal and does not timeout later', async () => {
     vi.useFakeTimers();
-    nwcMocks.useCancelableRequest = true;
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockReturnValue(new Promise(() => undefined));
     const controller = new AbortController();
 
     const response = makeNode().payInvoice({ invoice: BOLT11_INVOICE }, { signal: controller.signal });
@@ -293,18 +294,18 @@ describe('NwcNode.payInvoice', () => {
     await expect(response).rejects.toMatchObject({
       name: 'LniError',
       code: 'Canceled',
-      message: 'Failed to pay invoice: NWC pay invoice canceled because the request was aborted.',
     });
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.subscriptionClose).not.toHaveBeenCalled();
     expect(nwcMocks.close).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
   it('cancels active NIP-47 requests on close and close is idempotent', async () => {
     vi.useFakeTimers();
-    nwcMocks.useCancelableRequest = true;
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockReturnValue(new Promise(() => undefined));
     const node = makeNode();
 
     const response = node.payInvoice({ invoice: BOLT11_INVOICE });
@@ -317,11 +318,10 @@ describe('NwcNode.payInvoice', () => {
       code: 'Canceled',
       message: 'Failed to pay invoice: NWC request canceled because the node was closed.',
     });
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.subscriptionClose).not.toHaveBeenCalled();
     expect(nwcMocks.close).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(nwcMocks.subscriptionClose).toHaveBeenCalledTimes(1);
     expect(nwcMocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -377,12 +377,37 @@ describe('NwcNode.payInvoice', () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     await assertion;
-    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
-  it('passes httpTimeout to the SDK NIP-47 timeout values when the SDK request API is available', async () => {
+  it('bounds lookup fallback polling even when httpTimeout is disabled', async () => {
+    vi.useFakeTimers();
+    nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockResolvedValue(
+      nwcTransaction({
+        type: 'outgoing',
+        preimage: '',
+        settled_at: 150,
+      }),
+    );
+
+    const response = makeNodeWithTimeout(0).payInvoice({ invoice: BOLT11_INVOICE });
+    const assertion = expect(response).rejects.toMatchObject({
+      code: 'NetworkError',
+      message:
+        'Failed to pay invoice: NWC pay invoice lookup fallback timed out after 60s. Check that the wallet exposes a settled outgoing transaction with preimage via lookup_invoice or list_transactions.',
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await assertion;
+    expect(nwcMocks.lookupInvoice).toHaveBeenCalled();
+    expect(nwcMocks.close).not.toHaveBeenCalled();
+  });
+
+  it('uses public SDK request methods even when private SDK request internals exist', async () => {
     nwcMocks.usePrivateExecute = true;
-    nwcMocks.executeNip47Request.mockResolvedValue({
+    nwcMocks.payInvoice.mockResolvedValue({
       preimage: '',
       fees_paid: 21,
     });
@@ -394,24 +419,17 @@ describe('NwcNode.payInvoice', () => {
       preimage: '',
       feeMsats: 21,
     });
-    expect(nwcMocks.executeNip47Request).toHaveBeenCalledWith(
-      'pay_invoice',
-      {
-        invoice: BOLT11_INVOICE,
-        amount: undefined,
-      },
-      expect.any(Function),
-      {
-        replyTimeout: 15_000,
-        publishTimeout: 5_000,
-      },
-    );
-    expect(nwcMocks.payInvoice).not.toHaveBeenCalled();
+    expect(nwcMocks.executeNip47Request).not.toHaveBeenCalled();
+    expect(nwcMocks.payInvoice).toHaveBeenCalledWith({
+      invoice: BOLT11_INVOICE,
+      amount: undefined,
+    });
   });
 
-  it('times out and closes the NWC client when the websocket request never settles', async () => {
+  it('times out without closing the shared NWC client when the websocket request never settles', async () => {
     vi.useFakeTimers();
     nwcMocks.payInvoice.mockReturnValue(new Promise(() => undefined));
+    nwcMocks.lookupInvoice.mockReturnValue(new Promise(() => undefined));
 
     const response = makeNodeWithTimeout(0.001).payInvoice({ invoice: BOLT11_INVOICE });
     const assertion = expect(response).rejects.toMatchObject({
@@ -422,7 +440,7 @@ describe('NwcNode.payInvoice', () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await assertion;
-    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
   it('preserves typed NIP-47 wallet error codes from the SDK', async () => {
@@ -591,7 +609,7 @@ describe('NwcNode.lookupInvoice', () => {
     await vi.advanceTimersByTimeAsync(1);
     await assertion;
     expect(nwcMocks.listTransactions).not.toHaveBeenCalled();
-    expect(nwcMocks.close).toHaveBeenCalledTimes(1);
+    expect(nwcMocks.close).not.toHaveBeenCalled();
   });
 
   it('returns successful native lookup_invoice responses', async () => {

--- a/bindings/typescript/src/errors.ts
+++ b/bindings/typescript/src/errors.ts
@@ -4,6 +4,7 @@ export type LniErrorCode =
   | 'Json'
   | 'NetworkError'
   | 'InvalidInput'
+  | 'Canceled'
   | 'LnurlError'
   | 'NwcError';
 

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -1,4 +1,4 @@
-import { NWCClient, Nip47Error, Nip47PublishError, Nip47PublishTimeoutError, Nip47ReplyTimeoutError, Nip47ResponseDecodingError, Nip47ResponseValidationError, Nip47WalletError, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Method, type Nip47PayResponse, type Nip47TimeoutValues, type Nip47Transaction } from '@getalby/sdk/nwc';
+import { NWCClient, Nip47Error, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Method, type Nip47PayResponse, type Nip47Transaction } from '@getalby/sdk/nwc';
 import { decode as decodeBolt11, decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
 import { LniError, NwcError, type NwcErrorOperation } from '../errors.js';
 import { hexToBytes } from '../internal/encoding.js';
@@ -22,51 +22,6 @@ type NwcListTransaction = Partial<Omit<Nip47Transaction, 'type' | 'payment_hash'
 type NwcListTransactionsResponse = Omit<Nip47ListTransactionsResponse, 'transactions' | 'total_count'> & {
   transactions: NwcListTransaction[];
   total_count?: number;
-};
-
-type NwcClientWithTimeouts = {
-  executeNip47Request<T>(
-    nip47Method: Nip47Method,
-    params: unknown,
-    resultValidator: (result: T) => boolean,
-    timeoutValues?: Nip47TimeoutValues,
-  ): Promise<T>;
-};
-
-type NostrEventTemplate = {
-  kind: number;
-  created_at: number;
-  tags: string[][];
-  content: string;
-};
-
-type NostrEvent = NostrEventTemplate & {
-  id: string;
-};
-
-type NwcSubscription = {
-  close(): void;
-};
-
-type NwcPool = {
-  subscribe(
-    relayUrls: string[],
-    filters: { kinds: number[]; authors: string[]; '#e': string[] },
-    params: { onevent: (event: NostrEvent) => void | Promise<void> },
-  ): NwcSubscription;
-  publish(relayUrls: string[], event: NostrEvent): Promise<unknown>[];
-};
-
-type NwcCancelableClient = {
-  pool: NwcPool;
-  relayUrls: string[];
-  walletPubkey: string;
-  encryptionType: string;
-  encrypt(pubkey: string, content: string): Promise<string>;
-  decrypt(pubkey: string, content: string): Promise<string>;
-  signEvent(event: NostrEventTemplate): Promise<NostrEvent>;
-  _checkConnected(): Promise<void>;
-  _selectEncryptionType(): Promise<void>;
 };
 
 type ActiveNwcRequest = {
@@ -215,7 +170,6 @@ function resolveNwcTimeoutMs(timeoutSeconds: number | undefined): number | undef
 export class NwcNode implements LightningNode {
   private readonly client: NWCClient;
   private readonly timeoutMs: number | undefined;
-  private readonly nip47TimeoutValues: Nip47TimeoutValues | undefined;
   private readonly activeRequests = new Set<ActiveNwcRequest>();
   private closed = false;
 
@@ -224,12 +178,6 @@ export class NwcNode implements LightningNode {
     private readonly options: NodeRequestOptions = {},
   ) {
     this.timeoutMs = resolveNwcTimeoutMs(config.httpTimeout);
-    this.nip47TimeoutValues = this.timeoutMs
-      ? {
-          replyTimeout: this.timeoutMs,
-          publishTimeout: Math.min(this.timeoutMs, 5_000),
-        }
-      : undefined;
     this.client = new NWCClient({
       nostrWalletConnectUrl: config.nwcUri,
     });
@@ -419,7 +367,12 @@ export class NwcNode implements LightningNode {
       }
     }
 
-    const lookupFallback = this.pollPaidInvoiceResult(paymentHash, request.invoice, pollController.signal);
+    const lookupFallback = this.pollPaidInvoiceResult(
+      paymentHash,
+      request.invoice,
+      pollController.signal,
+      this.timeoutMs ?? DEFAULT_NWC_TIMEOUT_MS,
+    );
     void lookupFallback.catch(() => undefined);
 
     try {
@@ -434,18 +387,31 @@ export class NwcNode implements LightningNode {
     paymentHash: string,
     invoice: string,
     signal: AbortSignal,
+    timeoutMs: number,
   ): Promise<Nip47PayResponse> {
-    await this.delay(NWC_PAYMENT_LOOKUP_INITIAL_DELAY_MS, signal, 'pay invoice lookup fallback');
+    const deadlineAt = Date.now() + timeoutMs;
+    await this.delay(
+      Math.min(NWC_PAYMENT_LOOKUP_INITIAL_DELAY_MS, this.remainingLookupTimeoutMs(deadlineAt, timeoutMs)),
+      signal,
+      'pay invoice lookup fallback',
+    );
 
     while (!signal.aborted) {
       try {
-        const tx = await this.lookupInvoiceWithOptions(
+        const lookup = this.lookupInvoiceWithOptions(
           {
             paymentHash,
             search: invoice,
           },
           { signal },
           { suppressBufferedLookupErrors: true },
+        );
+        void lookup.catch(() => undefined);
+        const tx = await this.withLookupDeadline(
+          lookup,
+          this.remainingLookupTimeoutMs(deadlineAt, timeoutMs),
+          timeoutMs,
+          signal,
         );
 
         if (tx.type === 'outgoing' && tx.paymentHash === paymentHash && tx.settledAt > 0 && tx.preimage) {
@@ -455,15 +421,77 @@ export class NwcNode implements LightningNode {
           };
         }
       } catch (error) {
+        if (this.isLookupTimeoutError(error)) {
+          throw error;
+        }
+
         if (signal.aborted || (error instanceof LniError && error.code === 'Canceled')) {
           throw error;
         }
       }
 
-      await this.delay(NWC_PAYMENT_LOOKUP_POLL_INTERVAL_MS, signal, 'pay invoice lookup fallback');
+      await this.delay(
+        Math.min(NWC_PAYMENT_LOOKUP_POLL_INTERVAL_MS, this.remainingLookupTimeoutMs(deadlineAt, timeoutMs)),
+        signal,
+        'pay invoice lookup fallback',
+      );
     }
 
     throw this.createCancellationError('pay invoice lookup fallback', 'canceled because the request was aborted.');
+  }
+
+  private remainingLookupTimeoutMs(deadlineAt: number, timeoutMs: number): number {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw this.createPaymentLookupTimeoutError(timeoutMs);
+    }
+
+    return remainingMs;
+  }
+
+  private async withLookupDeadline<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    totalTimeoutMs: number,
+    signal: AbortSignal,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(this.createPaymentLookupTimeoutError(totalTimeoutMs));
+      }, timeoutMs);
+      onAbort = () => {
+        reject(this.createCancellationError('pay invoice lookup fallback', 'canceled because the request was aborted.'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+
+    try {
+      return await Promise.race([promise, timeout]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (onAbort) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    }
+  }
+
+  private createPaymentLookupTimeoutError(timeoutMs: number): LniError {
+    return new LniError(
+      'NetworkError',
+      `NWC pay invoice lookup fallback timed out after ${timeoutMs / 1000}s. Check that the wallet exposes a settled outgoing transaction with preimage via lookup_invoice or list_transactions.`,
+    );
+  }
+
+  private isLookupTimeoutError(error: unknown): boolean {
+    return (
+      error instanceof LniError &&
+      error.code === 'NetworkError' &&
+      error.message.startsWith('NWC pay invoice lookup fallback timed out')
+    );
   }
 
   private async delay(ms: number, signal: AbortSignal, operation: string): Promise<void> {
@@ -693,7 +721,7 @@ export class NwcNode implements LightningNode {
       throw this.createCancellationError(operation, 'canceled because the request was aborted.');
     }
 
-    const promise = fn();
+    const promise = Promise.resolve().then(fn);
     const timeoutMs = this.timeoutMs;
     if (!timeoutMs && !options.signal) {
       return promise;
@@ -722,7 +750,6 @@ export class NwcNode implements LightningNode {
       rejectWait = reject;
       if (timeoutMs) {
         timeoutId = setTimeout(() => {
-          this.client.close();
           activeRequest.cancel(
             new LniError(
               'NetworkError',
@@ -748,241 +775,14 @@ export class NwcNode implements LightningNode {
     }
   }
 
-  private getCancelableClient(): NwcCancelableClient | undefined {
-    const client = this.client as unknown as Partial<NwcCancelableClient>;
-    if (
-      client.pool &&
-      Array.isArray(client.relayUrls) &&
-      typeof client.walletPubkey === 'string' &&
-      typeof client.encrypt === 'function' &&
-      typeof client.decrypt === 'function' &&
-      typeof client.signEvent === 'function' &&
-      typeof client._checkConnected === 'function' &&
-      typeof client._selectEncryptionType === 'function'
-    ) {
-      return client as NwcCancelableClient;
-    }
-
-    return undefined;
-  }
-
-  private async executeCancelableNip47Request<T>(
-    operation: string,
-    method: Nip47Method,
-    params: unknown,
-    validator: (result: T) => boolean,
-    options: RequestCancellationOptions,
-  ): Promise<T> {
-    const client = this.getCancelableClient();
-    if (!client) {
-      throw new LniError('Api', 'Installed NWC SDK does not expose a cancellable NIP-47 request surface.');
-    }
-
-    if (this.closed) {
-      throw this.createCancellationError(operation, 'canceled because the node is closed.');
-    }
-
-    if (options.signal?.aborted) {
-      throw this.createCancellationError(operation, 'canceled because the request was aborted.');
-    }
-
-    return new Promise<T>((resolve, reject) => {
-      let settled = false;
-      let sub: NwcSubscription | undefined;
-      let replyTimeoutId: ReturnType<typeof setTimeout> | undefined;
-      let publishTimeoutId: ReturnType<typeof setTimeout> | undefined;
-      let replyTimeoutMessage = `reply timeout: request setup for ${method}`;
-
-      const cleanup = () => {
-        if (replyTimeoutId) {
-          clearTimeout(replyTimeoutId);
-          replyTimeoutId = undefined;
-        }
-        if (publishTimeoutId) {
-          clearTimeout(publishTimeoutId);
-          publishTimeoutId = undefined;
-        }
-        sub?.close();
-        sub = undefined;
-        options.signal?.removeEventListener('abort', onAbort);
-        this.activeRequests.delete(activeRequest);
-      };
-
-      const settleReject = (error: unknown) => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup();
-        reject(error);
-      };
-
-      const settleResolve = (result: T) => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup();
-        resolve(result);
-      };
-
-      const activeRequest: ActiveNwcRequest = {
-        cancel: settleReject,
-      };
-      const onAbort = () => settleReject(this.createCancellationError(operation, 'canceled because the request was aborted.'));
-      this.activeRequests.add(activeRequest);
-      options.signal?.addEventListener('abort', onAbort, { once: true });
-
-      const replyTimeout = this.nip47TimeoutValues?.replyTimeout ?? DEFAULT_NWC_TIMEOUT_MS;
-      replyTimeoutId = setTimeout(() => {
-        this.client.close();
-        settleReject(new Nip47ReplyTimeoutError(replyTimeoutMessage, 'INTERNAL'));
-      }, replyTimeout);
-
-      (async () => {
-        try {
-          await client._checkConnected();
-          if (settled) {
-            return;
-          }
-
-          await client._selectEncryptionType();
-          if (settled) {
-            return;
-          }
-
-          const command = {
-            method,
-            params,
-          };
-          const encryptedCommand = await client.encrypt(client.walletPubkey, JSON.stringify(command));
-          if (settled) {
-            return;
-          }
-
-          const eventTemplate = {
-            kind: 23194,
-            created_at: Math.floor(Date.now() / 1000),
-            tags: [
-              ['p', client.walletPubkey],
-              ['v', client.encryptionType === 'nip44_v2' ? '1.0' : '0.0'],
-              ['encryption', client.encryptionType],
-            ],
-            content: encryptedCommand,
-          };
-          const event = await client.signEvent(eventTemplate);
-          if (settled) {
-            return;
-          }
-          replyTimeoutMessage = `reply timeout: event ${event.id}`;
-
-          sub = client.pool.subscribe(
-            client.relayUrls,
-            {
-              kinds: [23195],
-              authors: [client.walletPubkey],
-              '#e': [event.id],
-            },
-            {
-              onevent: async (responseEvent) => {
-                if (settled) {
-                  return;
-                }
-
-                let decryptedContent: string;
-                try {
-                  decryptedContent = await client.decrypt(client.walletPubkey, responseEvent.content);
-                } catch (error) {
-                  settleReject(error);
-                  return;
-                }
-
-                let response: { result?: T; error?: { message?: string; code?: string } };
-                try {
-                  response = JSON.parse(decryptedContent);
-                } catch {
-                  settleReject(new Nip47ResponseDecodingError('failed to deserialize response', 'INTERNAL'));
-                  return;
-                }
-
-                if (response.result) {
-                  if (validator(response.result)) {
-                    settleResolve(response.result);
-                    return;
-                  }
-
-                  settleReject(
-                    new Nip47ResponseValidationError(
-                      `response from NWC failed validation: ${JSON.stringify(response.result)}`,
-                      'INTERNAL',
-                    ),
-                  );
-                  return;
-                }
-
-                settleReject(
-                  new Nip47WalletError(response.error?.message || 'unknown Error', response.error?.code || 'INTERNAL'),
-                );
-              },
-            },
-          );
-
-          const publishTimeout = this.nip47TimeoutValues?.publishTimeout ?? 5_000;
-          publishTimeoutId = setTimeout(() => {
-            this.client.close();
-            settleReject(new Nip47PublishTimeoutError(`publish timeout: ${event.id}`, 'INTERNAL'));
-          }, publishTimeout);
-
-          try {
-            await Promise.any(client.pool.publish(client.relayUrls, event));
-            if (publishTimeoutId) {
-              clearTimeout(publishTimeoutId);
-              publishTimeoutId = undefined;
-            }
-          } catch (error) {
-            settleReject(new Nip47PublishError(`failed to publish: ${error}`, 'INTERNAL'));
-          }
-        } catch (error) {
-          settleReject(error);
-        }
-      })();
-    });
-  }
-
-  private async executeSdkNip47Request<T>(
-    operation: string,
-    method: Nip47Method,
-    params: unknown,
-    validator: (result: T) => boolean,
-    fallback: () => Promise<T>,
-    options: RequestCancellationOptions,
-  ): Promise<T> {
-    const clientWithTimeouts = this.client as unknown as Partial<NwcClientWithTimeouts>;
-    const execute = clientWithTimeouts.executeNip47Request?.bind(this.client);
-
-    return this.withTimeout(operation, () => {
-      if (execute) {
-        return execute(method, params, validator, this.nip47TimeoutValues);
-      }
-
-      return fallback();
-    }, options);
-  }
-
   private async executeNip47Request<T>(
     operation: string,
-    method: Nip47Method,
-    params: unknown,
-    validator: (result: T) => boolean,
+    _method: Nip47Method,
+    _params: unknown,
+    _validator: (result: T) => boolean,
     fallback: () => Promise<T>,
     options: RequestCancellationOptions = {},
   ): Promise<T> {
-    if (this.getCancelableClient()) {
-      return this.executeCancelableNip47Request(operation, method, params, validator, options);
-    }
-
-    return this.executeSdkNip47Request(operation, method, params, validator, fallback, options);
+    return this.withTimeout(operation, fallback, options);
   }
 }

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -791,6 +791,7 @@ export class NwcNode implements LightningNode {
       let sub: NwcSubscription | undefined;
       let replyTimeoutId: ReturnType<typeof setTimeout> | undefined;
       let publishTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      let replyTimeoutMessage = `reply timeout: request setup for ${method}`;
 
       const cleanup = () => {
         if (replyTimeoutId) {
@@ -834,6 +835,12 @@ export class NwcNode implements LightningNode {
       this.activeRequests.add(activeRequest);
       options.signal?.addEventListener('abort', onAbort, { once: true });
 
+      const replyTimeout = this.nip47TimeoutValues?.replyTimeout ?? DEFAULT_NWC_TIMEOUT_MS;
+      replyTimeoutId = setTimeout(() => {
+        this.client.close();
+        settleReject(new Nip47ReplyTimeoutError(replyTimeoutMessage, 'INTERNAL'));
+      }, replyTimeout);
+
       (async () => {
         try {
           await client._checkConnected();
@@ -869,6 +876,7 @@ export class NwcNode implements LightningNode {
           if (settled) {
             return;
           }
+          replyTimeoutMessage = `reply timeout: event ${event.id}`;
 
           sub = client.pool.subscribe(
             client.relayUrls,
@@ -921,13 +929,9 @@ export class NwcNode implements LightningNode {
             },
           );
 
-          const replyTimeout = this.nip47TimeoutValues?.replyTimeout ?? DEFAULT_NWC_TIMEOUT_MS;
-          replyTimeoutId = setTimeout(() => {
-            settleReject(new Nip47ReplyTimeoutError(`reply timeout: event ${event.id}`, 'INTERNAL'));
-          }, replyTimeout);
-
           const publishTimeout = this.nip47TimeoutValues?.publishTimeout ?? 5_000;
           publishTimeoutId = setTimeout(() => {
+            this.client.close();
             settleReject(new Nip47PublishTimeoutError(`publish timeout: ${event.id}`, 'INTERNAL'));
           }, publishTimeout);
 

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -1,4 +1,4 @@
-import { NWCClient, Nip47Error, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Method, type Nip47PayResponse, type Nip47TimeoutValues, type Nip47Transaction } from '@getalby/sdk/nwc';
+import { NWCClient, Nip47Error, Nip47PublishError, Nip47PublishTimeoutError, Nip47ReplyTimeoutError, Nip47ResponseDecodingError, Nip47ResponseValidationError, Nip47WalletError, type Nip47GetBalanceResponse, type Nip47GetInfoResponse, type Nip47ListTransactionsResponse, type Nip47Method, type Nip47PayResponse, type Nip47TimeoutValues, type Nip47Transaction } from '@getalby/sdk/nwc';
 import { decode as decodeBolt11, decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
 import { LniError, NwcError, type NwcErrorOperation } from '../errors.js';
 import { hexToBytes } from '../internal/encoding.js';
@@ -8,9 +8,11 @@ import { pollInvoiceEvents } from '../internal/polling.js';
 import { sha256Hex } from '../internal/sha256.js';
 import { emptyNodeInfo, emptyTransaction, matchesSearch, parseOptionalNumber } from '../internal/transform.js';
 import { LnurlVerifyUnsupportedError, verifyLightningAddressPayRequest } from '../lnurl.js';
-import type { CreateInvoiceParams, CreateOfferParams, InvoiceEventCallback, LightningAddressInfo, LightningNode, ListTransactionsParams, LookupInvoiceParams, NodeInfo, NodeRequestOptions, NwcConfig, Offer, OnInvoiceEventParams, PayInvoiceParams, PayInvoiceResponse, Permissions, Transaction } from '../types.js';
+import type { CreateInvoiceParams, CreateOfferParams, InvoiceEventCallback, LightningAddressInfo, LightningNode, ListTransactionsParams, LookupInvoiceParams, NodeInfo, NodeRequestOptions, NwcConfig, Offer, OnInvoiceEventParams, PayInvoiceParams, PayInvoiceResponse, Permissions, RequestCancellationOptions, Transaction } from '../types.js';
 
 const DEFAULT_NWC_TIMEOUT_MS = 60_000;
+const NWC_PAYMENT_LOOKUP_INITIAL_DELAY_MS = 3_000;
+const NWC_PAYMENT_LOOKUP_POLL_INTERVAL_MS = 3_000;
 
 type NwcListTransaction = Partial<Omit<Nip47Transaction, 'type' | 'payment_hash'>> & {
   type?: Nip47Transaction['type'];
@@ -29,6 +31,46 @@ type NwcClientWithTimeouts = {
     resultValidator: (result: T) => boolean,
     timeoutValues?: Nip47TimeoutValues,
   ): Promise<T>;
+};
+
+type NostrEventTemplate = {
+  kind: number;
+  created_at: number;
+  tags: string[][];
+  content: string;
+};
+
+type NostrEvent = NostrEventTemplate & {
+  id: string;
+};
+
+type NwcSubscription = {
+  close(): void;
+};
+
+type NwcPool = {
+  subscribe(
+    relayUrls: string[],
+    filters: { kinds: number[]; authors: string[]; '#e': string[] },
+    params: { onevent: (event: NostrEvent) => void | Promise<void> },
+  ): NwcSubscription;
+  publish(relayUrls: string[], event: NostrEvent): Promise<unknown>[];
+};
+
+type NwcCancelableClient = {
+  pool: NwcPool;
+  relayUrls: string[];
+  walletPubkey: string;
+  encryptionType: string;
+  encrypt(pubkey: string, content: string): Promise<string>;
+  decrypt(pubkey: string, content: string): Promise<string>;
+  signEvent(event: NostrEventTemplate): Promise<NostrEvent>;
+  _checkConnected(): Promise<void>;
+  _selectEncryptionType(): Promise<void>;
+};
+
+type ActiveNwcRequest = {
+  cancel(reason: LniError): void;
 };
 
 function toNwcError(error: unknown, operation: NwcErrorOperation): NwcError | undefined {
@@ -174,6 +216,8 @@ export class NwcNode implements LightningNode {
   private readonly client: NWCClient;
   private readonly timeoutMs: number | undefined;
   private readonly nip47TimeoutValues: Nip47TimeoutValues | undefined;
+  private readonly activeRequests = new Set<ActiveNwcRequest>();
+  private closed = false;
 
   constructor(
     private readonly config: NwcConfig,
@@ -192,6 +236,12 @@ export class NwcNode implements LightningNode {
   }
 
   close(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.cancelActiveRequests('NWC request canceled because the node was closed.');
     this.client.close();
   }
 
@@ -301,21 +351,19 @@ export class NwcNode implements LightningNode {
     return nwcTransactionToLniTransaction(tx);
   }
 
-  async payInvoice(params: PayInvoiceParams): Promise<PayInvoiceResponse> {
+  async payInvoice(params: PayInvoiceParams, options: RequestCancellationOptions = {}): Promise<PayInvoiceResponse> {
     const request = {
       invoice: params.invoice,
       amount: params.amountMsats,
     };
-    const response = await this.executeNip47Request(
-      'pay invoice',
-      'pay_invoice',
-      request,
-      (result: Nip47PayResponse) => Boolean(result),
-      () => this.client.payInvoice(request),
-    ).catch((error) => {
+    const response = await this.payInvoiceWithLookupFallback(request, options).catch((error) => {
       throwNwcOrApiError(error, 'pay_invoice', 'Failed to pay invoice');
     });
 
+    return this.mapPayInvoiceResponse(response);
+  }
+
+  private async mapPayInvoiceResponse(response: Nip47PayResponse): Promise<PayInvoiceResponse> {
     let paymentHash = '';
     if (response.preimage) {
       let preimageBytes: Uint8Array;
@@ -335,6 +383,107 @@ export class NwcNode implements LightningNode {
     };
   }
 
+  private async payInvoiceWithLookupFallback(
+    request: { invoice: string; amount?: number },
+    options: RequestCancellationOptions,
+  ): Promise<Nip47PayResponse> {
+    const directController = new AbortController();
+    const pollController = new AbortController();
+    const abortInternalRequests = () => {
+      directController.abort();
+      pollController.abort();
+    };
+
+    if (options.signal?.aborted) {
+      abortInternalRequests();
+    } else {
+      options.signal?.addEventListener('abort', abortInternalRequests, { once: true });
+    }
+
+    const directRequest = this.executeNip47Request(
+      'pay invoice',
+      'pay_invoice',
+      request,
+      (result: Nip47PayResponse) => Boolean(result),
+      () => this.client.payInvoice(request),
+      { signal: directController.signal },
+    );
+    void directRequest.catch(() => undefined);
+
+    const paymentHash = paymentHashFromInvoice(request.invoice);
+    if (!paymentHash) {
+      try {
+        return await directRequest;
+      } finally {
+        options.signal?.removeEventListener('abort', abortInternalRequests);
+      }
+    }
+
+    const lookupFallback = this.pollPaidInvoiceResult(paymentHash, request.invoice, pollController.signal);
+    void lookupFallback.catch(() => undefined);
+
+    try {
+      return await Promise.race([directRequest, lookupFallback]);
+    } finally {
+      abortInternalRequests();
+      options.signal?.removeEventListener('abort', abortInternalRequests);
+    }
+  }
+
+  private async pollPaidInvoiceResult(
+    paymentHash: string,
+    invoice: string,
+    signal: AbortSignal,
+  ): Promise<Nip47PayResponse> {
+    await this.delay(NWC_PAYMENT_LOOKUP_INITIAL_DELAY_MS, signal, 'pay invoice lookup fallback');
+
+    while (!signal.aborted) {
+      try {
+        const tx = await this.lookupInvoiceWithOptions(
+          {
+            paymentHash,
+            search: invoice,
+          },
+          { signal },
+          { suppressBufferedLookupErrors: true },
+        );
+
+        if (tx.type === 'outgoing' && tx.paymentHash === paymentHash && tx.settledAt > 0 && tx.preimage) {
+          return {
+            preimage: tx.preimage,
+            fees_paid: tx.feesPaid,
+          };
+        }
+      } catch (error) {
+        if (signal.aborted || (error instanceof LniError && error.code === 'Canceled')) {
+          throw error;
+        }
+      }
+
+      await this.delay(NWC_PAYMENT_LOOKUP_POLL_INTERVAL_MS, signal, 'pay invoice lookup fallback');
+    }
+
+    throw this.createCancellationError('pay invoice lookup fallback', 'canceled because the request was aborted.');
+  }
+
+  private async delay(ms: number, signal: AbortSignal, operation: string): Promise<void> {
+    if (signal.aborted) {
+      throw this.createCancellationError(operation, 'canceled because the request was aborted.');
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        reject(this.createCancellationError(operation, 'canceled because the request was aborted.'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
   async createOffer(_params: CreateOfferParams): Promise<Offer> {
     throw new LniError('Api', 'NWC does not support offers (BOLT12) yet.');
   }
@@ -352,6 +501,14 @@ export class NwcNode implements LightningNode {
   }
 
   async lookupInvoice(params: LookupInvoiceParams): Promise<Transaction> {
+    return this.lookupInvoiceWithOptions(params);
+  }
+
+  private async lookupInvoiceWithOptions(
+    params: LookupInvoiceParams,
+    options: RequestCancellationOptions = {},
+    lookupOptions: { suppressBufferedLookupErrors?: boolean } = {},
+  ): Promise<Transaction> {
     const paymentHash = params.paymentHash ?? paymentHashFromInvoice(params.search ?? '');
     const invoice = params.search;
 
@@ -376,23 +533,32 @@ export class NwcNode implements LightningNode {
                 payment_hash: paymentHash || undefined,
                 invoice: paymentHash ? undefined : invoice,
               }),
+            options,
           ),
         errorLogs,
       );
 
       return nwcTransactionToLniTransaction(tx);
     } catch (error) {
+      if (error instanceof LniError && error.code === 'Canceled') {
+        throw error;
+      }
+
       if (error instanceof LniError && error.code === 'NetworkError') {
-        replayConsoleErrors(errorLogs);
+        if (!lookupOptions.suppressBufferedLookupErrors) {
+          replayConsoleErrors(errorLogs);
+        }
         throwNwcOrApiError(error, 'lookup_invoice', 'Failed to lookup invoice');
       }
 
-      const fallback = await this.lookupInvoiceFromTransactions(paymentHash, invoice);
+      const fallback = await this.lookupInvoiceFromTransactions(paymentHash, invoice, options);
       if (fallback) {
         return fallback;
       }
 
-      replayConsoleErrors(errorLogs);
+      if (!lookupOptions.suppressBufferedLookupErrors) {
+        replayConsoleErrors(errorLogs);
+      }
       throwNwcOrApiError(error, 'lookup_invoice', 'Failed to lookup invoice');
     }
   }
@@ -400,6 +566,7 @@ export class NwcNode implements LightningNode {
   private async lookupInvoiceFromTransactions(
     paymentHash: string,
     invoice: string | undefined,
+    options: RequestCancellationOptions = {},
   ): Promise<Transaction | undefined> {
     const pageSize = 100;
     let offset = 0;
@@ -422,6 +589,7 @@ export class NwcNode implements LightningNode {
               limit: pageSize,
               offset,
             }),
+          options,
         );
         const page = response as NwcListTransactionsResponse;
         const transactions = page.transactions.map((tx) => nwcTransactionToLniTransaction(tx));
@@ -502,41 +670,290 @@ export class NwcNode implements LightningNode {
     });
   }
 
-  private async withTimeout<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+  private cancelActiveRequests(message: string): void {
+    for (const request of [...this.activeRequests]) {
+      request.cancel(new LniError('Canceled', message));
+    }
+  }
+
+  private createCancellationError(operation: string, message: string): LniError {
+    return new LniError('Canceled', `NWC ${operation} ${message}`);
+  }
+
+  private async withTimeout<T>(
+    operation: string,
+    fn: () => Promise<T>,
+    options: RequestCancellationOptions = {},
+  ): Promise<T> {
+    if (this.closed) {
+      throw this.createCancellationError(operation, 'canceled because the node is closed.');
+    }
+
+    if (options.signal?.aborted) {
+      throw this.createCancellationError(operation, 'canceled because the request was aborted.');
+    }
+
     const promise = fn();
     const timeoutMs = this.timeoutMs;
-    if (!timeoutMs) {
+    if (!timeoutMs && !options.signal) {
       return promise;
     }
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timeoutId = setTimeout(() => {
-        this.client.close();
-        reject(
-          new LniError(
-            'NetworkError',
-            `NWC ${operation} timed out after ${timeoutMs / 1000}s. Check that the relay websocket is reachable and the wallet connection still exists.`,
-          ),
-        );
-      }, timeoutMs);
+    let settled = false;
+    let rejectWait: (error: LniError) => void = () => undefined;
+    const activeRequest: ActiveNwcRequest = {
+      cancel: (reason) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        options.signal?.removeEventListener('abort', onAbort);
+        this.activeRequests.delete(activeRequest);
+        rejectWait(reason);
+      },
+    };
+    const onAbort = () => activeRequest.cancel(this.createCancellationError(operation, 'canceled because the request was aborted.'));
+    const wait = new Promise<never>((_resolve, reject) => {
+      rejectWait = reject;
+      if (timeoutMs) {
+        timeoutId = setTimeout(() => {
+          this.client.close();
+          activeRequest.cancel(
+            new LniError(
+              'NetworkError',
+              `NWC ${operation} timed out after ${timeoutMs / 1000}s. Check that the relay websocket is reachable and the wallet connection still exists.`,
+            ),
+          );
+        }, timeoutMs);
+      }
     });
+    this.activeRequests.add(activeRequest);
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    void promise.catch(() => undefined);
 
     try {
-      return await Promise.race([promise, timeout]);
+      return await Promise.race([promise, wait]);
     } finally {
+      settled = true;
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
+      options.signal?.removeEventListener('abort', onAbort);
+      this.activeRequests.delete(activeRequest);
     }
   }
 
-  private async executeNip47Request<T>(
+  private getCancelableClient(): NwcCancelableClient | undefined {
+    const client = this.client as unknown as Partial<NwcCancelableClient>;
+    if (
+      client.pool &&
+      Array.isArray(client.relayUrls) &&
+      typeof client.walletPubkey === 'string' &&
+      typeof client.encrypt === 'function' &&
+      typeof client.decrypt === 'function' &&
+      typeof client.signEvent === 'function' &&
+      typeof client._checkConnected === 'function' &&
+      typeof client._selectEncryptionType === 'function'
+    ) {
+      return client as NwcCancelableClient;
+    }
+
+    return undefined;
+  }
+
+  private async executeCancelableNip47Request<T>(
+    operation: string,
+    method: Nip47Method,
+    params: unknown,
+    validator: (result: T) => boolean,
+    options: RequestCancellationOptions,
+  ): Promise<T> {
+    const client = this.getCancelableClient();
+    if (!client) {
+      throw new LniError('Api', 'Installed NWC SDK does not expose a cancellable NIP-47 request surface.');
+    }
+
+    if (this.closed) {
+      throw this.createCancellationError(operation, 'canceled because the node is closed.');
+    }
+
+    if (options.signal?.aborted) {
+      throw this.createCancellationError(operation, 'canceled because the request was aborted.');
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      let sub: NwcSubscription | undefined;
+      let replyTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      let publishTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = () => {
+        if (replyTimeoutId) {
+          clearTimeout(replyTimeoutId);
+          replyTimeoutId = undefined;
+        }
+        if (publishTimeoutId) {
+          clearTimeout(publishTimeoutId);
+          publishTimeoutId = undefined;
+        }
+        sub?.close();
+        sub = undefined;
+        options.signal?.removeEventListener('abort', onAbort);
+        this.activeRequests.delete(activeRequest);
+      };
+
+      const settleReject = (error: unknown) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      const settleResolve = (result: T) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        resolve(result);
+      };
+
+      const activeRequest: ActiveNwcRequest = {
+        cancel: settleReject,
+      };
+      const onAbort = () => settleReject(this.createCancellationError(operation, 'canceled because the request was aborted.'));
+      this.activeRequests.add(activeRequest);
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+
+      (async () => {
+        try {
+          await client._checkConnected();
+          if (settled) {
+            return;
+          }
+
+          await client._selectEncryptionType();
+          if (settled) {
+            return;
+          }
+
+          const command = {
+            method,
+            params,
+          };
+          const encryptedCommand = await client.encrypt(client.walletPubkey, JSON.stringify(command));
+          if (settled) {
+            return;
+          }
+
+          const eventTemplate = {
+            kind: 23194,
+            created_at: Math.floor(Date.now() / 1000),
+            tags: [
+              ['p', client.walletPubkey],
+              ['v', client.encryptionType === 'nip44_v2' ? '1.0' : '0.0'],
+              ['encryption', client.encryptionType],
+            ],
+            content: encryptedCommand,
+          };
+          const event = await client.signEvent(eventTemplate);
+          if (settled) {
+            return;
+          }
+
+          sub = client.pool.subscribe(
+            client.relayUrls,
+            {
+              kinds: [23195],
+              authors: [client.walletPubkey],
+              '#e': [event.id],
+            },
+            {
+              onevent: async (responseEvent) => {
+                if (settled) {
+                  return;
+                }
+
+                let decryptedContent: string;
+                try {
+                  decryptedContent = await client.decrypt(client.walletPubkey, responseEvent.content);
+                } catch (error) {
+                  settleReject(error);
+                  return;
+                }
+
+                let response: { result?: T; error?: { message?: string; code?: string } };
+                try {
+                  response = JSON.parse(decryptedContent);
+                } catch {
+                  settleReject(new Nip47ResponseDecodingError('failed to deserialize response', 'INTERNAL'));
+                  return;
+                }
+
+                if (response.result) {
+                  if (validator(response.result)) {
+                    settleResolve(response.result);
+                    return;
+                  }
+
+                  settleReject(
+                    new Nip47ResponseValidationError(
+                      `response from NWC failed validation: ${JSON.stringify(response.result)}`,
+                      'INTERNAL',
+                    ),
+                  );
+                  return;
+                }
+
+                settleReject(
+                  new Nip47WalletError(response.error?.message || 'unknown Error', response.error?.code || 'INTERNAL'),
+                );
+              },
+            },
+          );
+
+          const replyTimeout = this.nip47TimeoutValues?.replyTimeout ?? DEFAULT_NWC_TIMEOUT_MS;
+          replyTimeoutId = setTimeout(() => {
+            settleReject(new Nip47ReplyTimeoutError(`reply timeout: event ${event.id}`, 'INTERNAL'));
+          }, replyTimeout);
+
+          const publishTimeout = this.nip47TimeoutValues?.publishTimeout ?? 5_000;
+          publishTimeoutId = setTimeout(() => {
+            settleReject(new Nip47PublishTimeoutError(`publish timeout: ${event.id}`, 'INTERNAL'));
+          }, publishTimeout);
+
+          try {
+            await Promise.any(client.pool.publish(client.relayUrls, event));
+            if (publishTimeoutId) {
+              clearTimeout(publishTimeoutId);
+              publishTimeoutId = undefined;
+            }
+          } catch (error) {
+            settleReject(new Nip47PublishError(`failed to publish: ${error}`, 'INTERNAL'));
+          }
+        } catch (error) {
+          settleReject(error);
+        }
+      })();
+    });
+  }
+
+  private async executeSdkNip47Request<T>(
     operation: string,
     method: Nip47Method,
     params: unknown,
     validator: (result: T) => boolean,
     fallback: () => Promise<T>,
+    options: RequestCancellationOptions,
   ): Promise<T> {
     const clientWithTimeouts = this.client as unknown as Partial<NwcClientWithTimeouts>;
     const execute = clientWithTimeouts.executeNip47Request?.bind(this.client);
@@ -547,6 +964,21 @@ export class NwcNode implements LightningNode {
       }
 
       return fallback();
-    });
+    }, options);
+  }
+
+  private async executeNip47Request<T>(
+    operation: string,
+    method: Nip47Method,
+    params: unknown,
+    validator: (result: T) => boolean,
+    fallback: () => Promise<T>,
+    options: RequestCancellationOptions = {},
+  ): Promise<T> {
+    if (this.getCancelableClient()) {
+      return this.executeCancelableNip47Request(operation, method, params, validator, options);
+    }
+
+    return this.executeSdkNip47Request(operation, method, params, validator, fallback, options);
   }
 }

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -161,6 +161,10 @@ export interface PayInvoiceParams {
   isAmp?: boolean;
 }
 
+export interface RequestCancellationOptions {
+  signal?: AbortSignal;
+}
+
 export interface LookupInvoiceParams {
   paymentHash?: string;
   search?: string;
@@ -268,7 +272,7 @@ export interface LightningNode {
   getPermissions(): Promise<Permissions>;
   getInfo(): Promise<NodeInfo>;
   createInvoice(params: CreateInvoiceParams): Promise<Transaction>;
-  payInvoice(params: PayInvoiceParams): Promise<PayInvoiceResponse>;
+  payInvoice(params: PayInvoiceParams, options?: RequestCancellationOptions): Promise<PayInvoiceResponse>;
   createOffer(params: CreateOfferParams): Promise<Offer>;
   getOffer(search?: string): Promise<Offer>;
   listOffers(search?: string): Promise<Offer[]>;

--- a/crates/lni/nwc/api.rs
+++ b/crates/lni/nwc/api.rs
@@ -12,10 +12,14 @@ use std::future::Future;
 use std::str::FromStr;
 use std::time::Duration;
 
+const NWC_PAYMENT_LOOKUP_INITIAL_DELAY: Duration = Duration::from_secs(3);
+const NWC_PAYMENT_LOOKUP_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
 // Helper function to create NWC client
 async fn create_nwc_client(config: &NwcConfig) -> Result<NWC, ApiError> {
-    let uri = NostrWalletConnectURI::from_str(&config.nwc_uri)
-        .map_err(|e| ApiError::Api { reason: format!("Invalid NWC URI: {}", e) })?;
+    let uri = NostrWalletConnectURI::from_str(&config.nwc_uri).map_err(|e| ApiError::Api {
+        reason: format!("Invalid NWC URI: {}", e),
+    })?;
 
     let relay_opts = RelayOptions::default()
         .verify_subscriptions(true)
@@ -83,69 +87,76 @@ fn map_nwc_error(error: nwc::Error, fallback_prefix: &str) -> ApiError {
 }
 
 pub async fn get_info(config: NwcConfig) -> Result<NodeInfo, ApiError> {
-        let nwc = create_nwc_client(&config).await?;
-        let timeout = nwc_request_timeout(&config);
-        
-        // Get balance first
-        let balance = execute_nwc_request(timeout, nwc.get_balance(), "Failed to get balance").await?;
-        
-        // Try to get more info using get_info method if available
-        let info_result = execute_nwc_request(timeout, nwc.get_info(), "Failed to get info").await;
-        
-        match info_result {
-            Ok(nwc_info) => {
-                Ok(NodeInfo {
-                    alias: nwc_info.alias.unwrap_or_else(|| "NWC Node".to_string()),
-                    color: nwc_info.color.unwrap_or_default(),
-                    pubkey: nwc_info.pubkey.map(|pk| pk.to_string()).unwrap_or_else(|| {
-                        // If no pubkey in get_info, try to extract from URI
-                        config.nwc_uri.split("?").next()
-                            .and_then(|part| part.strip_prefix("nostr+walletconnect://"))
-                            .unwrap_or_default()
-                            .to_string()
-                    }),
-                    network: nwc_info.network.unwrap_or_else(|| "mainnet".to_string()),
-                    block_height: nwc_info.block_height.unwrap_or(0) as i64,
-                    block_hash: nwc_info.block_hash.unwrap_or_default(),
-                    send_balance_msat: balance as i64,
-                    receive_balance_msat: 0, // NWC doesn't provide separate receive balance
-                    fee_credit_balance_msat: 0,
-                    unsettled_send_balance_msat: 0,
-                    unsettled_receive_balance_msat: 0,
-                    pending_open_send_balance: 0,
-                    pending_open_receive_balance: 0,
-                })
-            }
-            Err(_) => {
-                // Fallback: extract pubkey from NWC URI if get_info is not available
-                let pubkey = config.nwc_uri.split("?").next()
-                    .and_then(|part| part.strip_prefix("nostr+walletconnect://"))
-                    .unwrap_or_default()
-                    .to_string();
-                
-                Ok(NodeInfo {
-                    alias: "NWC Node".to_string(),
-                    color: "".to_string(),
-                    pubkey,
-                    network: "mainnet".to_string(),
-                    block_height: 0,
-                    block_hash: "".to_string(),
-                    send_balance_msat: balance as i64,
-                    receive_balance_msat: 0,
-                    fee_credit_balance_msat: 0,
-                    unsettled_send_balance_msat: 0,
-                    unsettled_receive_balance_msat: 0,
-                    pending_open_send_balance: 0,
-                    pending_open_receive_balance: 0,
-                })
-            }
+    let nwc = create_nwc_client(&config).await?;
+    let timeout = nwc_request_timeout(&config);
+
+    // Get balance first
+    let balance = execute_nwc_request(timeout, nwc.get_balance(), "Failed to get balance").await?;
+
+    // Try to get more info using get_info method if available
+    let info_result = execute_nwc_request(timeout, nwc.get_info(), "Failed to get info").await;
+
+    match info_result {
+        Ok(nwc_info) => {
+            Ok(NodeInfo {
+                alias: nwc_info.alias.unwrap_or_else(|| "NWC Node".to_string()),
+                color: nwc_info.color.unwrap_or_default(),
+                pubkey: nwc_info.pubkey.map(|pk| pk.to_string()).unwrap_or_else(|| {
+                    // If no pubkey in get_info, try to extract from URI
+                    config
+                        .nwc_uri
+                        .split("?")
+                        .next()
+                        .and_then(|part| part.strip_prefix("nostr+walletconnect://"))
+                        .unwrap_or_default()
+                        .to_string()
+                }),
+                network: nwc_info.network.unwrap_or_else(|| "mainnet".to_string()),
+                block_height: nwc_info.block_height.unwrap_or(0) as i64,
+                block_hash: nwc_info.block_hash.unwrap_or_default(),
+                send_balance_msat: balance as i64,
+                receive_balance_msat: 0, // NWC doesn't provide separate receive balance
+                fee_credit_balance_msat: 0,
+                unsettled_send_balance_msat: 0,
+                unsettled_receive_balance_msat: 0,
+                pending_open_send_balance: 0,
+                pending_open_receive_balance: 0,
+            })
         }
+        Err(_) => {
+            // Fallback: extract pubkey from NWC URI if get_info is not available
+            let pubkey = config
+                .nwc_uri
+                .split("?")
+                .next()
+                .and_then(|part| part.strip_prefix("nostr+walletconnect://"))
+                .unwrap_or_default()
+                .to_string();
+
+            Ok(NodeInfo {
+                alias: "NWC Node".to_string(),
+                color: "".to_string(),
+                pubkey,
+                network: "mainnet".to_string(),
+                block_height: 0,
+                block_hash: "".to_string(),
+                send_balance_msat: balance as i64,
+                receive_balance_msat: 0,
+                fee_credit_balance_msat: 0,
+                unsettled_send_balance_msat: 0,
+                unsettled_receive_balance_msat: 0,
+                pending_open_send_balance: 0,
+                pending_open_receive_balance: 0,
+            })
+        }
+    }
 }
 
 pub async fn get_permissions(config: NwcConfig) -> Result<crate::Permissions, ApiError> {
     let nwc = create_nwc_client(&config).await?;
     let timeout = nwc_request_timeout(&config);
-    let info = execute_nwc_request(timeout, nwc.get_info(), "Failed to get NWC permissions").await?;
+    let info =
+        execute_nwc_request(timeout, nwc.get_info(), "Failed to get NWC permissions").await?;
 
     if info.methods.is_empty() {
         Ok(crate::permissions::nwc_method_permissions())
@@ -161,24 +172,30 @@ pub fn lightning_address_from_nwc_uri(config: &NwcConfig) -> Result<String, ApiE
         .replace("nostr+walletconnect://", "http://")
         .replace("nostrwalletconnect:", "http://")
         .replace("nostr+walletconnect:", "http://");
-    let uri = reqwest::Url::parse(&normalized_uri)
-        .map_err(|e| ApiError::Api { reason: format!("Invalid NWC URI: {}", e) })?;
+    let uri = reqwest::Url::parse(&normalized_uri).map_err(|e| ApiError::Api {
+        reason: format!("Invalid NWC URI: {}", e),
+    })?;
     let lightning_address = uri
         .query_pairs()
         .find(|(key, _)| key == "lud16")
         .map(|(_, value)| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| ApiError::InvalidInput("NWC URI does not include a lud16 Lightning Address".to_string()))?;
+        .ok_or_else(|| {
+            ApiError::InvalidInput("NWC URI does not include a lud16 Lightning Address".to_string())
+        })?;
 
     match crate::lnurl::PaymentDestination::parse(&lightning_address)? {
         crate::lnurl::PaymentDestination::LightningAddress { .. } => Ok(lightning_address),
-        _ => Err(ApiError::InvalidInput("NWC lud16 value must be a Lightning Address".to_string())),
+        _ => Err(ApiError::InvalidInput(
+            "NWC lud16 value must be a Lightning Address".to_string(),
+        )),
     }
 }
 
 pub async fn get_lightning_address(config: NwcConfig) -> Result<NwcLightningAddress, ApiError> {
     let lightning_address = lightning_address_from_nwc_uri(&config)?;
-    let lnurl_verify_supported = crate::lnurl::lightning_address_lnurl_verify_supported(&lightning_address).await;
+    let lnurl_verify_supported =
+        crate::lnurl::lightning_address_lnurl_verify_supported(&lightning_address).await;
 
     Ok(NwcLightningAddress {
         lightning_address,
@@ -186,19 +203,27 @@ pub async fn get_lightning_address(config: NwcConfig) -> Result<NwcLightningAddr
     })
 }
 
-pub async fn create_invoice(config: NwcConfig, params: CreateInvoiceParams) -> Result<Transaction, ApiError> {
+pub async fn create_invoice(
+    config: NwcConfig,
+    params: CreateInvoiceParams,
+) -> Result<Transaction, ApiError> {
     let nwc = create_nwc_client(&config).await?;
     let timeout = nwc_request_timeout(&config);
-    
+
     let request = MakeInvoiceRequest {
         amount: params.amount_msats.unwrap_or(0) as u64,
         description: params.description.clone(),
         description_hash: None,
         expiry: params.expiry.map(|e| e as u64),
     };
-    
-    let response = execute_nwc_request(timeout, nwc.make_invoice(request), "Failed to create invoice").await?;
-    
+
+    let response = execute_nwc_request(
+        timeout,
+        nwc.make_invoice(request),
+        "Failed to create invoice",
+    )
+    .await?;
+
     Ok(Transaction {
         type_: "incoming".to_string(),
         invoice: response.invoice,
@@ -216,40 +241,178 @@ pub async fn create_invoice(config: NwcConfig, params: CreateInvoiceParams) -> R
     })
 }
 
-pub async fn pay_invoice(config: NwcConfig, params: PayInvoiceParams) -> Result<PayInvoiceResponse, ApiError> {
+pub async fn pay_invoice(
+    config: NwcConfig,
+    params: PayInvoiceParams,
+) -> Result<PayInvoiceResponse, ApiError> {
     let nwc = create_nwc_client(&config).await?;
     let timeout = nwc_request_timeout(&config);
-    
-    let request = PayInvoiceRequest::new(params.invoice);
-    
-    let response = execute_nwc_request(timeout, nwc.pay_invoice(request), "Failed to pay invoice").await?;
-    
-    // Compute payment hash from preimage (payment_hash = SHA256(preimage))
-    let payment_hash = if !response.preimage.is_empty() {
-        let preimage_bytes = hex::decode(&response.preimage)
-            .map_err(|e| ApiError::Api { reason: format!("Invalid preimage hex: {}", e) })?;
+
+    let invoice = params.invoice;
+    let amount = match params.amount_msats {
+        Some(amount) if amount < 0 => {
+            return Err(ApiError::InvalidInput(
+                "amount_msats must be non-negative".to_string(),
+            ));
+        }
+        Some(amount) => Some(amount as u64),
+        None => None,
+    };
+    let request = PayInvoiceRequest {
+        amount,
+        ..PayInvoiceRequest::new(invoice.clone())
+    };
+
+    let direct_request = request.clone();
+    let direct_payment = async {
+        let response = execute_nwc_request(
+            timeout,
+            nwc.pay_invoice(direct_request),
+            "Failed to pay invoice",
+        )
+        .await?;
+        nwc_pay_response_to_lni(response)
+    };
+
+    let Some(payment_hash) = invoice_payment_hash(Some(&invoice)) else {
+        return direct_payment.await;
+    };
+
+    tokio::select! {
+        result = direct_payment => result,
+        result = poll_paid_invoice_result(config, payment_hash, invoice, timeout) => result,
+    }
+}
+
+fn nwc_pay_response_to_lni(
+    response: nip47::PayInvoiceResponse,
+) -> Result<PayInvoiceResponse, ApiError> {
+    pay_response_from_preimage(response.preimage, response.fees_paid.unwrap_or(0) as i64)
+}
+
+fn pay_response_from_preimage(
+    preimage: String,
+    fee_msats: i64,
+) -> Result<PayInvoiceResponse, ApiError> {
+    let payment_hash = if !preimage.is_empty() {
+        let preimage_bytes = hex::decode(&preimage).map_err(|e| ApiError::Api {
+            reason: format!("Invalid preimage hex: {}", e),
+        })?;
         let mut hasher = Sha256::new();
         hasher.update(preimage_bytes);
         hex::encode(hasher.finalize())
     } else {
         "".to_string()
     };
-    
+
     Ok(PayInvoiceResponse {
         payment_hash,
-        preimage: response.preimage,
-        fee_msats: 0, // Not available in response
+        preimage,
+        fee_msats,
     })
+}
+
+async fn poll_paid_invoice_result(
+    config: NwcConfig,
+    payment_hash: String,
+    invoice: String,
+    timeout: Duration,
+) -> Result<PayInvoiceResponse, ApiError> {
+    let started_at = tokio::time::Instant::now();
+    bounded_sleep(started_at, timeout, NWC_PAYMENT_LOOKUP_INITIAL_DELAY).await?;
+
+    loop {
+        let remaining = remaining_timeout(started_at, timeout)?;
+        let lookup_result = tokio::time::timeout(
+            remaining,
+            lookup_paid_invoice_candidate(config.clone(), payment_hash.clone(), invoice.clone()),
+        )
+        .await
+        .map_err(|_| nwc_timeout_error(timeout))?;
+
+        if let Ok(Some(transaction)) = lookup_result {
+            if let Some(response) = paid_transaction_to_response(&transaction, &payment_hash)? {
+                return Ok(response);
+            }
+        }
+
+        bounded_sleep(started_at, timeout, NWC_PAYMENT_LOOKUP_POLL_INTERVAL).await?;
+    }
+}
+
+async fn lookup_paid_invoice_candidate(
+    config: NwcConfig,
+    payment_hash: String,
+    invoice: String,
+) -> Result<Option<Transaction>, ApiError> {
+    match lookup_invoice(
+        config.clone(),
+        Some(payment_hash.clone()),
+        Some(invoice.clone()),
+    )
+    .await
+    {
+        Ok(transaction) => Ok(Some(transaction)),
+        Err(_) => {
+            lookup_invoice_from_transactions(config, Some(&payment_hash), Some(&invoice)).await
+        }
+    }
+}
+
+fn paid_transaction_to_response(
+    transaction: &Transaction,
+    expected_payment_hash: &str,
+) -> Result<Option<PayInvoiceResponse>, ApiError> {
+    if transaction.type_ != "outgoing"
+        || transaction.settled_at <= 0
+        || transaction.preimage.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let response = pay_response_from_preimage(transaction.preimage.clone(), transaction.fees_paid)?;
+    if response.payment_hash != expected_payment_hash {
+        return Ok(None);
+    }
+
+    Ok(Some(response))
+}
+
+fn remaining_timeout(
+    started_at: tokio::time::Instant,
+    timeout: Duration,
+) -> Result<Duration, ApiError> {
+    timeout
+        .checked_sub(started_at.elapsed())
+        .filter(|remaining| *remaining > Duration::ZERO)
+        .ok_or_else(|| nwc_timeout_error(timeout))
+}
+
+async fn bounded_sleep(
+    started_at: tokio::time::Instant,
+    timeout: Duration,
+    requested_delay: Duration,
+) -> Result<(), ApiError> {
+    let remaining = remaining_timeout(started_at, timeout)?;
+    tokio::time::sleep(requested_delay.min(remaining)).await;
+    Ok(())
 }
 
 pub async fn get_offer(_config: &NwcConfig, _search: Option<String>) -> Result<Offer, ApiError> {
     // NWC doesn't support offers/BOLT12 yet
-    Err(ApiError::Api { reason: "NWC does not support offers (BOLT12) yet".to_string() })
+    Err(ApiError::Api {
+        reason: "NWC does not support offers (BOLT12) yet".to_string(),
+    })
 }
 
-pub async fn list_offers(_config: &NwcConfig, _search: Option<String>) -> Result<Vec<Offer>, ApiError> {
+pub async fn list_offers(
+    _config: &NwcConfig,
+    _search: Option<String>,
+) -> Result<Vec<Offer>, ApiError> {
     // NWC doesn't support offers/BOLT12 yet
-    Err(ApiError::Api { reason: "NWC does not support offers (BOLT12) yet".to_string() })
+    Err(ApiError::Api {
+        reason: "NWC does not support offers (BOLT12) yet".to_string(),
+    })
 }
 
 pub async fn pay_offer(
@@ -259,7 +422,9 @@ pub async fn pay_offer(
     _payer_note: Option<String>,
 ) -> Result<PayInvoiceResponse, ApiError> {
     // NWC doesn't support offers/BOLT12 yet
-    Err(ApiError::Api { reason: "NWC does not support offers (BOLT12) yet".to_string() })
+    Err(ApiError::Api {
+        reason: "NWC does not support offers (BOLT12) yet".to_string(),
+    })
 }
 
 pub async fn lookup_invoice(
@@ -272,12 +437,22 @@ pub async fn lookup_invoice(
         .or_else(|| invoice_payment_hash(invoice.as_deref()));
     let request = LookupInvoiceRequest {
         payment_hash: lookup_payment_hash.clone(),
-        invoice: if lookup_payment_hash.is_some() { None } else { invoice.clone() },
+        invoice: if lookup_payment_hash.is_some() {
+            None
+        } else {
+            invoice.clone()
+        },
     };
     let nwc = create_nwc_client(&config).await?;
     let timeout = nwc_request_timeout(&config);
 
-    let response = match execute_nwc_request(timeout, nwc.lookup_invoice(request), "Failed to lookup invoice").await {
+    let response = match execute_nwc_request(
+        timeout,
+        nwc.lookup_invoice(request),
+        "Failed to lookup invoice",
+    )
+    .await
+    {
         Ok(response) => response,
         Err(error) => {
             if is_network_error(&error) {
@@ -298,7 +473,10 @@ pub async fn lookup_invoice(
         }
     };
 
-    Ok(lookup_response_to_transaction(response, lookup_payment_hash.or(payment_hash)))
+    Ok(lookup_response_to_transaction(
+        response,
+        lookup_payment_hash.or(payment_hash),
+    ))
 }
 
 async fn lookup_invoice_from_transactions(
@@ -384,7 +562,10 @@ fn lookup_response_to_transaction(
     }
 }
 
-pub async fn list_transactions(config: NwcConfig, params: ListTransactionsParams) -> Result<Vec<Transaction>, ApiError> {
+pub async fn list_transactions(
+    config: NwcConfig,
+    params: ListTransactionsParams,
+) -> Result<Vec<Transaction>, ApiError> {
     list_transactions_page(&config, &params, None).await
 }
 
@@ -408,7 +589,12 @@ async fn list_transactions_page_raw(
     let request = list_transactions_request(params, offset);
     let nwc = create_nwc_client(config).await?;
     let timeout = nwc_request_timeout(config);
-    let response = execute_nwc_request(timeout, nwc.list_transactions(request), "Failed to list transactions").await?;
+    let response = execute_nwc_request(
+        timeout,
+        nwc.list_transactions(request),
+        "Failed to list transactions",
+    )
+    .await?;
 
     Ok(response
         .into_iter()
@@ -416,7 +602,10 @@ async fn list_transactions_page_raw(
         .collect())
 }
 
-fn list_transactions_request(params: &ListTransactionsParams, offset: Option<u64>) -> ListTransactionsRequest {
+fn list_transactions_request(
+    params: &ListTransactionsParams,
+    offset: Option<u64>,
+) -> ListTransactionsRequest {
     let from = params.created_after.unwrap_or(params.from).max(0) as u64;
     let until = params
         .created_before
@@ -509,7 +698,9 @@ pub async fn decode_offer(offer: String) -> Result<String, ApiError> {
 }
 
 // Core logic shared with other implementations - processes lookup result and determines status
-fn process_invoice_lookup_result(transaction_result: Result<Transaction, ApiError>) -> (String, Option<Transaction>) {
+fn process_invoice_lookup_result(
+    transaction_result: Result<Transaction, ApiError>,
+) -> (String, Option<Transaction>) {
     match transaction_result {
         Ok(transaction) => {
             if transaction.settled_at > 0 {
@@ -565,10 +756,10 @@ pub async fn poll_invoice_events<F>(
             params.search.clone(),
         )
         .await;
-        
+
         let (status, transaction) = process_invoice_lookup_result(lookup_result);
         let should_continue = handle_poll_status(&status, transaction, &mut callback);
-        
+
         if !should_continue {
             break;
         }
@@ -658,6 +849,128 @@ mod tests {
     }
 
     #[test]
+    fn maps_nwc_pay_response_to_lni_payment_result() {
+        let response = nwc_pay_response_to_lni(nip47::PayInvoiceResponse {
+            preimage: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            fees_paid: Some(21),
+        })
+        .expect("valid preimage should map");
+
+        assert_eq!(
+            response.payment_hash,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"
+        );
+        assert_eq!(
+            response.preimage,
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(response.fee_msats, 21);
+    }
+
+    #[test]
+    fn maps_settled_outgoing_transaction_to_payment_result() {
+        let transaction = Transaction {
+            type_: "outgoing".to_string(),
+            payment_hash: "hash".to_string(),
+            invoice: "invoice".to_string(),
+            description: String::new(),
+            description_hash: String::new(),
+            preimage: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            amount_msats: 1000,
+            fees_paid: 21,
+            created_at: 0,
+            expires_at: 0,
+            settled_at: 10,
+            payer_note: None,
+            external_id: None,
+        };
+
+        let response = paid_transaction_to_response(
+            &transaction,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925",
+        )
+        .expect("valid preimage should map")
+        .expect("settled outgoing transaction should be a payment result");
+
+        assert_eq!(
+            response.payment_hash,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"
+        );
+        assert_eq!(response.fee_msats, 21);
+    }
+
+    #[test]
+    fn ignores_transactions_without_complete_outgoing_payment_result() {
+        let mut transaction = Transaction {
+            type_: "outgoing".to_string(),
+            payment_hash: "hash".to_string(),
+            invoice: "invoice".to_string(),
+            description: String::new(),
+            description_hash: String::new(),
+            preimage: String::new(),
+            amount_msats: 1000,
+            fees_paid: 21,
+            created_at: 0,
+            expires_at: 0,
+            settled_at: 10,
+            payer_note: None,
+            external_id: None,
+        };
+
+        assert!(paid_transaction_to_response(
+            &transaction,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925",
+        )
+        .unwrap()
+        .is_none());
+
+        transaction.preimage =
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        transaction.settled_at = 0;
+        assert!(paid_transaction_to_response(
+            &transaction,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925",
+        )
+        .unwrap()
+        .is_none());
+
+        transaction.settled_at = 10;
+        transaction.type_ = "incoming".to_string();
+        assert!(paid_transaction_to_response(
+            &transaction,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn ignores_settled_transaction_when_preimage_hash_does_not_match_expected_payment_hash() {
+        let transaction = Transaction {
+            type_: "outgoing".to_string(),
+            payment_hash: "different-hash".to_string(),
+            invoice: "invoice".to_string(),
+            description: String::new(),
+            description_hash: String::new(),
+            preimage: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            amount_msats: 1000,
+            fees_paid: 21,
+            created_at: 0,
+            expires_at: 0,
+            settled_at: 10,
+            payer_note: None,
+            external_id: None,
+        };
+
+        assert!(paid_transaction_to_response(&transaction, "expected-hash")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
     fn normalizes_nwc_request_timeout_to_at_least_one_second() {
         let config = NwcConfig {
             nwc_uri: String::new(),
@@ -728,8 +1041,20 @@ mod tests {
         };
 
         assert!(transaction_matches_lookup(&transaction, Some("hash"), None));
-        assert!(!transaction_matches_lookup(&transaction, Some("other"), Some("invoice")));
-        assert!(transaction_matches_lookup(&transaction, None, Some("invoice")));
-        assert!(!transaction_matches_lookup(&transaction, Some("other"), Some("other")));
+        assert!(!transaction_matches_lookup(
+            &transaction,
+            Some("other"),
+            Some("invoice")
+        ));
+        assert!(transaction_matches_lookup(
+            &transaction,
+            None,
+            Some("invoice")
+        ));
+        assert!(!transaction_matches_lookup(
+            &transaction,
+            Some("other"),
+            Some("other")
+        ));
     }
 }

--- a/crates/lni/nwc/api.rs
+++ b/crates/lni/nwc/api.rs
@@ -278,9 +278,36 @@ pub async fn pay_invoice(
         return direct_payment.await;
     };
 
+    prefer_payment_result_over_direct_error(
+        direct_payment,
+        poll_paid_invoice_result(config, payment_hash, invoice, timeout),
+    )
+    .await
+}
+
+async fn prefer_payment_result_over_direct_error<D, P>(
+    direct_payment: D,
+    poll_payment: P,
+) -> Result<PayInvoiceResponse, ApiError>
+where
+    D: Future<Output = Result<PayInvoiceResponse, ApiError>>,
+    P: Future<Output = Result<PayInvoiceResponse, ApiError>>,
+{
+    tokio::pin!(direct_payment);
+    tokio::pin!(poll_payment);
+
     tokio::select! {
-        result = direct_payment => result,
-        result = poll_paid_invoice_result(config, payment_hash, invoice, timeout) => result,
+        direct_result = &mut direct_payment => match direct_result {
+            Ok(response) => Ok(response),
+            Err(direct_error) => match poll_payment.await {
+                Ok(response) => Ok(response),
+                Err(_) => Err(direct_error),
+            },
+        },
+        poll_result = &mut poll_payment => match poll_result {
+            Ok(response) => Ok(response),
+            Err(_) => direct_payment.await,
+        },
     }
 }
 
@@ -866,6 +893,63 @@ mod tests {
             "0000000000000000000000000000000000000000000000000000000000000000"
         );
         assert_eq!(response.fee_msats, 21);
+    }
+
+    #[tokio::test]
+    async fn payment_poll_result_wins_after_direct_payment_error() {
+        let response = prefer_payment_result_over_direct_error(
+            async {
+                Err(ApiError::Nwc {
+                    code: "INTERNAL".to_string(),
+                    message: "direct failure".to_string(),
+                })
+            },
+            async {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                Ok(PayInvoiceResponse {
+                    payment_hash:
+                        "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"
+                            .to_string(),
+                    preimage: "0000000000000000000000000000000000000000000000000000000000000000"
+                        .to_string(),
+                    fee_msats: 21,
+                })
+            },
+        )
+        .await
+        .expect("poll result should win");
+
+        assert_eq!(
+            response.payment_hash,
+            "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_payment_error_is_returned_when_poll_also_fails() {
+        let error = prefer_payment_result_over_direct_error(
+            async {
+                Err(ApiError::Nwc {
+                    code: "PAYMENT_FAILED".to_string(),
+                    message: "direct failure".to_string(),
+                })
+            },
+            async {
+                Err(ApiError::NetworkError(
+                    "lookup fallback timed out".to_string(),
+                ))
+            },
+        )
+        .await
+        .expect_err("direct error should be returned when poll also fails");
+
+        match error {
+            ApiError::Nwc { code, message } => {
+                assert_eq!(code, "PAYMENT_FAILED");
+                assert_eq!(message, "direct failure");
+            }
+            other => panic!("expected direct NWC error, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canceling payment requests in the TypeScript API.
  * Payment requests can now fall back to a lookup flow and continue until the payment is confirmed or canceled.

* **Bug Fixes**
  * Improved payment handling so settled payments are recognized even when the initial response is delayed or missing.
  * Added better validation and error reporting for invalid payment amounts and address lookups.

* **Tests**
  * Expanded integration and unit coverage for cancellation, timeouts, and payment confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->