### PR TITLE
expo polyfill fix

### DIFF
--- a/bindings/typescript-arkade/package-lock.json
+++ b/bindings/typescript-arkade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -21,12 +21,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.14"
+        "@sunnyln/lni": "^0.2.15"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",
@@ -52,7 +52,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/arkade-boltz.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.14"
+    "@sunnyln/lni": "^0.2.15"
   },
   "dependencies": {
     "@arkade-os/boltz-swap": "^0.3.3",

--- a/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -50,12 +50,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.14"
+        "@sunnyln/lni": "^0.2.15"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript-spark/examples/spark-web/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -43,12 +43,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.14"
+        "@sunnyln/lni": "^0.2.15"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",
@@ -74,7 +74,7 @@
     },
     "../../../typescript-arkade": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -89,7 +89,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.14"
+        "@sunnyln/lni": "^0.2.15"
       }
     },
     "node_modules/@arkade-os/boltz-swap": {

--- a/bindings/typescript-spark/package-lock.json
+++ b/bindings/typescript-spark/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -29,12 +29,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.14"
+        "@sunnyln/lni": "^0.2.15"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",
@@ -56,7 +56,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/spark.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.14"
+    "@sunnyln/lni": "^0.2.15"
   },
   "dependencies": {
     "@buildonspark/spark-sdk": "^0.6.3",

--- a/bindings/typescript/package-lock.json
+++ b/bindings/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",

--- a/bindings/typescript/src/__tests__/expo-polyfills.test.ts
+++ b/bindings/typescript/src/__tests__/expo-polyfills.test.ts
@@ -1,9 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const expoCrypto = vi.hoisted(() => ({
+  digest: vi.fn(),
+  loadCount: 0,
+}));
+
+vi.mock('expo-crypto', () => {
+  expoCrypto.loadCount += 1;
+
+  return {
+    CryptoDigestAlgorithm: { SHA256: 'SHA-256' },
+    digest: expoCrypto.digest,
+  };
+});
+
 const originalMessageChannelDescriptor = Object.getOwnPropertyDescriptor(
   globalThis,
   'MessageChannel'
 );
+const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
 
 function restoreMessageChannel(): void {
   if (originalMessageChannelDescriptor) {
@@ -21,6 +36,22 @@ function clearMessageChannel(): void {
   });
 }
 
+function restoreCrypto(): void {
+  if (originalCryptoDescriptor) {
+    Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
+  } else {
+    delete (globalThis as { crypto?: Crypto }).crypto;
+  }
+}
+
+function clearCrypto(): void {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  });
+}
+
 function flushScheduledMessage(): Promise<void> {
   return new Promise((resolve) => {
     const scheduler = globalThis.setImmediate ?? ((fn: () => void) => setTimeout(fn, 0));
@@ -30,7 +61,9 @@ function flushScheduledMessage(): Promise<void> {
 
 afterEach(() => {
   vi.resetModules();
+  vi.clearAllMocks();
   restoreMessageChannel();
+  restoreCrypto();
 });
 
 describe('expo-polyfills', () => {
@@ -68,5 +101,19 @@ describe('expo-polyfills', () => {
     installExpoPolyfills();
 
     expect(globalThis.MessageChannel).toBe(ExistingMessageChannel);
+  });
+
+  it('loads expo-crypto statically and preserves the SHA-256 fallback result', async () => {
+    clearCrypto();
+    const bytes = Uint8Array.from([1, 2, 3]);
+    expoCrypto.digest.mockResolvedValueOnce(Uint8Array.from([0xab, 0xcd]).buffer);
+
+    await import('../expo-polyfills.js');
+
+    expect(expoCrypto.loadCount).toBe(1);
+
+    const { sha256Hex } = await import('../internal/sha256.js');
+    await expect(sha256Hex(bytes)).resolves.toBe('abcd');
+    expect(expoCrypto.digest).toHaveBeenCalledWith('SHA-256', bytes);
   });
 });

--- a/bindings/typescript/src/expo-polyfills.ts
+++ b/bindings/typescript/src/expo-polyfills.ts
@@ -1,3 +1,5 @@
+import * as Crypto from 'expo-crypto';
+
 import { registerSha256DigestFallback } from './internal/sha256.js';
 
 type MessageListener = (event: MessageEvent) => void;
@@ -111,7 +113,6 @@ export function installExpoPolyfills(): void {
   }
 
   registerSha256DigestFallback(async (bytes) => {
-    const Crypto = await import('expo-crypto');
     return Crypto.digest(Crypto.CryptoDigestAlgorithm.SHA256, bytes as BufferSource);
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SHA-256 fallback behavior by loading the Expo cryptography module once while preserving expected digest results.

* **Tests**
  * Added coverage confirming cryptography initialization, SHA-256 output, and proper cleanup of global environment state.

* **Chores**
  * Updated TypeScript package versions to 0.2.15 and aligned related peer dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->