### PR TITLE
preimage from payInvoice

### DIFF
--- a/bindings/typescript-arkade/package-lock.json
+++ b/bindings/typescript-arkade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -21,12 +21,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.15"
+        "@sunnyln/lni": "^0.2.16"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",
@@ -52,7 +52,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/arkade-boltz.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.15"
+    "@sunnyln/lni": "^0.2.16"
   },
   "dependencies": {
     "@arkade-os/boltz-swap": "^0.3.3",

--- a/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -50,12 +50,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.15"
+        "@sunnyln/lni": "^0.2.16"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript-spark/examples/spark-web/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -43,12 +43,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.15"
+        "@sunnyln/lni": "^0.2.16"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",
@@ -74,7 +74,7 @@
     },
     "../../../typescript-arkade": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -89,7 +89,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.15"
+        "@sunnyln/lni": "^0.2.16"
       }
     },
     "node_modules/@arkade-os/boltz-swap": {

--- a/bindings/typescript-spark/package-lock.json
+++ b/bindings/typescript-spark/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -29,12 +29,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.15"
+        "@sunnyln/lni": "^0.2.16"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",
@@ -56,7 +56,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/spark.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.15"
+    "@sunnyln/lni": "^0.2.16"
   },
   "dependencies": {
     "@buildonspark/spark-sdk": "^0.6.3",

--- a/bindings/typescript/package-lock.json
+++ b/bindings/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",

--- a/bindings/typescript/src/__tests__/blink.test.ts
+++ b/bindings/typescript/src/__tests__/blink.test.ts
@@ -87,6 +87,54 @@ describe('BlinkNode Lightning payments', () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it('returns the invoice payment hash when the send response omits the preimage', async () => {
+    const fetchMock = vi.fn<FetchLike>(async (_input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+
+      if (body.query.includes('query Me')) {
+        return meResponse();
+      }
+
+      if (body.query.includes('mutation lnInvoiceFeeProbe')) {
+        return jsonResponse({
+          data: {
+            lnInvoiceFeeProbe: {
+              amount: 2,
+              errors: [],
+            },
+          },
+        });
+      }
+
+      if (body.query.includes('mutation LnInvoicePaymentSend')) {
+        return jsonResponse({
+          data: {
+            lnInvoicePaymentSend: {
+              status: 'SUCCESS',
+              errors: [],
+              transaction: {
+                settlementVia: {},
+              },
+            },
+          },
+        });
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const node = new BlinkNode(
+      { apiKey: 'test-token', baseUrl: 'https://api.blink.test/graphql' },
+      { fetch: fetchMock }
+    );
+
+    await expect(node.payInvoice({ invoice: BOLT11 })).resolves.toEqual({
+      paymentHash: '0001020304050607080900010203040506070809000102030405060708090102',
+      preimage: '',
+      feeMsats: 2_000,
+    });
+  });
 });
 
 describe('BlinkNode on-chain payments', () => {

--- a/bindings/typescript/src/__tests__/blink.test.ts
+++ b/bindings/typescript/src/__tests__/blink.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { BlinkNode } from '../nodes/blink.js';
 import type { FetchLike } from '../types.js';
 
+const BOLT11 =
+  'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh';
+
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -29,6 +32,62 @@ function meResponse() {
     },
   });
 }
+
+describe('BlinkNode Lightning payments', () => {
+  it('returns the preimage selected by the send mutation', async () => {
+    const fetchMock = vi.fn<FetchLike>(async (_input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+
+      if (body.query.includes('query Me')) {
+        return meResponse();
+      }
+
+      if (body.query.includes('mutation lnInvoiceFeeProbe')) {
+        return jsonResponse({
+          data: {
+            lnInvoiceFeeProbe: {
+              amount: 2,
+              errors: [],
+            },
+          },
+        });
+      }
+
+      if (body.query.includes('mutation LnInvoicePaymentSend')) {
+        expect(body.query).toContain('... on SettlementViaLn');
+        expect(body.query).toContain('... on SettlementViaIntraLedger');
+
+        return jsonResponse({
+          data: {
+            lnInvoicePaymentSend: {
+              status: 'SUCCESS',
+              errors: [],
+              transaction: {
+                settlementVia: {
+                  preImage: 'settled-preimage',
+                },
+              },
+            },
+          },
+        });
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const node = new BlinkNode(
+      { apiKey: 'test-token', baseUrl: 'https://api.blink.test/graphql' },
+      { fetch: fetchMock }
+    );
+
+    await expect(node.payInvoice({ invoice: BOLT11 })).resolves.toEqual({
+      paymentHash: '0001020304050607080900010203040506070809000102030405060708090102',
+      preimage: 'settled-preimage',
+      feeMsats: 2_000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
 
 describe('BlinkNode on-chain payments', () => {
   it('prepares an on-chain transaction using Blink fee estimate and speed mapping', async () => {

--- a/bindings/typescript/src/__tests__/integration/blink.real.test.ts
+++ b/bindings/typescript/src/__tests__/integration/blink.real.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, expect } from 'vitest';
 import { BlinkNode } from '../../nodes/blink.js';
 import {
@@ -85,6 +86,26 @@ describe('Real integration from crates/lni/.env > BlinkNode', () => {
     },
     timeout
   );
+
+  // itIf(enabled && hasEnv('BLINK_TEST_PAYMENT_REQUEST'))(
+  //   'payInvoice returns a valid Lightning preimage',
+  //   async () => {
+  //     const node = makeNode();
+  //     const payment = await node.payInvoice({
+  //       invoice: process.env.BLINK_TEST_PAYMENT_REQUEST!,
+  //     });
+  //     console.log('Blink payInvoice result:', payment);
+  //     expect(payment.paymentHash).toMatch(/^[0-9a-f]{64}$/i);
+  //     expect(payment.preimage).toMatch(/^[0-9a-f]{64}$/i);
+  //     expect(payment.feeMsats).toBeGreaterThanOrEqual(0);
+
+  //     const paymentHashFromPreimage = createHash('sha256')
+  //       .update(Buffer.from(payment.preimage, 'hex'))
+  //       .digest('hex');
+  //     expect(paymentHashFromPreimage).toBe(payment.paymentHash.toLowerCase());
+  //   },
+  //   timeout
+  // );
 
   itIf(enabled && hasEnv('BLINK_ONCHAIN_TEST_ADDRESS'))(
     'prepareOnchainTransaction + optionally payOnchain',

--- a/bindings/typescript/src/__tests__/integration/blink.real.test.ts
+++ b/bindings/typescript/src/__tests__/integration/blink.real.test.ts
@@ -87,25 +87,25 @@ describe('Real integration from crates/lni/.env > BlinkNode', () => {
     timeout
   );
 
-  // itIf(enabled && hasEnv('BLINK_TEST_PAYMENT_REQUEST'))(
-  //   'payInvoice returns a valid Lightning preimage',
-  //   async () => {
-  //     const node = makeNode();
-  //     const payment = await node.payInvoice({
-  //       invoice: process.env.BLINK_TEST_PAYMENT_REQUEST!,
-  //     });
-  //     console.log('Blink payInvoice result:', payment);
-  //     expect(payment.paymentHash).toMatch(/^[0-9a-f]{64}$/i);
-  //     expect(payment.preimage).toMatch(/^[0-9a-f]{64}$/i);
-  //     expect(payment.feeMsats).toBeGreaterThanOrEqual(0);
+  itIf(enabled && hasEnv('BLINK_TEST_PAYMENT_REQUEST'))(
+    'payInvoice returns a valid Lightning preimage',
+    async () => {
+      const node = makeNode();
+      const payment = await node.payInvoice({
+        invoice: process.env.BLINK_TEST_PAYMENT_REQUEST!,
+      });
+      console.log('Blink payInvoice result:', payment);
+      expect(payment.paymentHash).toMatch(/^[0-9a-f]{64}$/i);
+      expect(payment.preimage).toMatch(/^[0-9a-f]{64}$/i);
+      expect(payment.feeMsats).toBeGreaterThanOrEqual(0);
 
-  //     const paymentHashFromPreimage = createHash('sha256')
-  //       .update(Buffer.from(payment.preimage, 'hex'))
-  //       .digest('hex');
-  //     expect(paymentHashFromPreimage).toBe(payment.paymentHash.toLowerCase());
-  //   },
-  //   timeout
-  // );
+      const paymentHashFromPreimage = createHash('sha256')
+        .update(Buffer.from(payment.preimage, 'hex'))
+        .digest('hex');
+      expect(paymentHashFromPreimage).toBe(payment.paymentHash.toLowerCase());
+    },
+    timeout
+  );
 
   itIf(enabled && hasEnv('BLINK_ONCHAIN_TEST_ADDRESS'))(
     'prepareOnchainTransaction + optionally payOnchain',

--- a/bindings/typescript/src/__tests__/integration/strike.real.test.ts
+++ b/bindings/typescript/src/__tests__/integration/strike.real.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, expect } from 'vitest';
 import { StrikeNode } from '../../nodes/strike.js';
 import {
@@ -83,6 +84,27 @@ describe('Real integration from crates/lni/.env > StrikeNode', () => {
           throw lastError;
         }
       }, ['no receive found', 'http 404']);
+    },
+    timeout
+  );
+
+  itIf(enabled && hasEnv('STRIKE_TEST_PAYMENT_REQUEST'))(
+    'payInvoice returns a valid Lightning preimage',
+    async () => {
+      const node = makeNode();
+      const payment = await node.payInvoice({
+        invoice: process.env.STRIKE_TEST_PAYMENT_REQUEST!,
+      });
+      console.log('Strike payInvoice result:', payment);
+
+      expect(payment.paymentHash).toMatch(/^[0-9a-f]{64}$/i);
+      expect(payment.preimage).toMatch(/^[0-9a-f]{64}$/i);
+      expect(payment.feeMsats).toBeGreaterThanOrEqual(0);
+
+      const paymentHashFromPreimage = createHash('sha256')
+        .update(Buffer.from(payment.preimage, 'hex'))
+        .digest('hex');
+      expect(paymentHashFromPreimage).toBe(payment.paymentHash.toLowerCase());
     },
     timeout
   );

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -133,6 +133,40 @@ describe('StrikeNode error normalization', () => {
 });
 
 describe('StrikeNode Lightning payments', () => {
+  it('preserves a preimage returned by execute when payment.read is unavailable', async () => {
+    const fetchMock = vi.fn<FetchLike>(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://api.strike.test/v1/payment-quotes/lightning') {
+        return jsonResponse({ paymentQuoteId: 'quote-1' });
+      }
+
+      if (url === 'https://api.strike.test/v1/payment-quotes/quote-1/execute') {
+        return jsonResponse({
+          paymentId: 'payment-1',
+          lightning: {
+            preImage: 'execute-preimage',
+            networkFee: { amount: '0.00000001', currency: 'BTC' },
+          },
+        });
+      }
+
+      return new Response('forbidden', { status: 403 });
+    });
+
+    const node = new StrikeNode(
+      { apiKey: 'test-token', baseUrl: 'https://api.strike.test/v1' },
+      { fetch: fetchMock }
+    );
+
+    await expect(node.payInvoice({ invoice: BOLT11 })).resolves.toEqual({
+      paymentHash: '0001020304050607080900010203040506070809000102030405060708090102',
+      preimage: 'execute-preimage',
+      feeMsats: 1_000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns the settled preimage from the outgoing payment record', async () => {
     vi.useFakeTimers();
     let paymentReads = 0;

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -3,6 +3,9 @@ import { NwcError } from '../errors.js';
 import { StrikeNode } from '../nodes/strike.js';
 import type { FetchLike } from '../types.js';
 
+const BOLT11 =
+  'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh';
+
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -126,6 +129,61 @@ describe('StrikeNode error normalization', () => {
       provider: 'strike',
       providerStatus: 401,
     });
+  });
+});
+
+describe('StrikeNode Lightning payments', () => {
+  it('returns the settled preimage from the outgoing payment record', async () => {
+    vi.useFakeTimers();
+    let paymentReads = 0;
+
+    try {
+      const fetchMock = vi.fn<FetchLike>(async (input) => {
+        const url = String(input);
+
+        if (url === 'https://api.strike.test/v1/payment-quotes/lightning') {
+          return jsonResponse({ paymentQuoteId: 'quote-1' });
+        }
+
+        if (url === 'https://api.strike.test/v1/payment-quotes/quote-1/execute') {
+          return jsonResponse({ paymentId: 'payment-1' });
+        }
+
+        if (url === 'https://api.strike.test/v1/payments/payment-1') {
+          paymentReads += 1;
+          return jsonResponse({
+            id: 'payment-1',
+            state: 'COMPLETED',
+            created: '2026-07-16T12:00:00Z',
+            amount: { amount: '0.00002500', currency: 'BTC' },
+            lightning: {
+              paymentHash: 'provider-payment-hash',
+              preImage: paymentReads > 1 ? 'settled-preimage' : undefined,
+              networkFee: { amount: '0.00000001', currency: 'BTC' },
+            },
+          });
+        }
+
+        return new Response('not found', { status: 404 });
+      });
+
+      const node = new StrikeNode(
+        { apiKey: 'test-token', baseUrl: 'https://api.strike.test/v1' },
+        { fetch: fetchMock }
+      );
+
+      const paymentPromise = node.payInvoice({ invoice: BOLT11 });
+      await vi.runAllTimersAsync();
+
+      await expect(paymentPromise).resolves.toEqual({
+        paymentHash: 'provider-payment-hash',
+        preimage: 'settled-preimage',
+        feeMsats: 1_000,
+      });
+      expect(paymentReads).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -219,6 +219,68 @@ describe('StrikeNode Lightning payments', () => {
       vi.useRealTimers();
     }
   });
+
+  it('retries transient outgoing payment record failures', async () => {
+    vi.useFakeTimers();
+    let paymentReads = 0;
+
+    try {
+      const fetchMock = vi.fn<FetchLike>(async (input) => {
+        const url = String(input);
+
+        if (url === 'https://api.strike.test/v1/payment-quotes/lightning') {
+          return jsonResponse({ paymentQuoteId: 'quote-1' });
+        }
+
+        if (url === 'https://api.strike.test/v1/payment-quotes/quote-1/execute') {
+          return jsonResponse({ paymentId: 'payment-1' });
+        }
+
+        if (url === 'https://api.strike.test/v1/payments/payment-1') {
+          paymentReads += 1;
+          if (paymentReads === 1) {
+            return new Response('not found', { status: 404 });
+          }
+          if (paymentReads === 2) {
+            return new Response('unavailable', { status: 503 });
+          }
+          if (paymentReads === 3) {
+            return new Response('{not-json', { status: 200 });
+          }
+          return jsonResponse({
+            id: 'payment-1',
+            state: 'COMPLETED',
+            created: '2026-07-16T12:00:00Z',
+            amount: { amount: '0.00002500', currency: 'BTC' },
+            lightning: {
+              paymentHash: 'provider-payment-hash',
+              preImage: 'settled-preimage',
+              networkFee: { amount: '0.00000001', currency: 'BTC' },
+            },
+          });
+        }
+
+        return new Response('not found', { status: 404 });
+      });
+
+      const node = new StrikeNode(
+        { apiKey: 'test-token', baseUrl: 'https://api.strike.test/v1' },
+        { fetch: fetchMock }
+      );
+
+      const paymentPromise = node.payInvoice({ invoice: BOLT11 });
+      await vi.runAllTimersAsync();
+
+      await expect(paymentPromise).resolves.toEqual({
+        paymentHash: 'provider-payment-hash',
+        preimage: 'settled-preimage',
+        feeMsats: 1_000,
+      });
+      expect(paymentReads).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('StrikeNode on-chain payments', () => {

--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -708,12 +708,10 @@ export class BlinkNode implements LightningNode, OnchainPayments {
 
     const preimage = payment.lnInvoicePaymentSend.transaction?.settlementVia?.preImage ?? '';
     let paymentHash = '';
-    if (preimage) {
-      try {
-        paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
-      } catch {
-        // The payment succeeded, so preserve the provider result even if the invoice cannot decode.
-      }
+    try {
+      paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
+    } catch {
+      // The payment succeeded, so preserve the provider result even if the invoice cannot decode.
     }
     return {
       paymentHash,

--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -1,5 +1,5 @@
 import { LniError, NwcError, type NwcErrorCode, type NwcErrorOperation } from '../errors.js';
-import { decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
+import { decode as decodeBolt11, decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
 import {
   mapProviderMessage,
   throwNormalizedProviderError,
@@ -88,6 +88,11 @@ interface BlinkFeeProbeResponse {
 interface BlinkPaymentSendResponse {
   lnInvoicePaymentSend: {
     status: string;
+    transaction?: {
+      settlementVia?: {
+        preImage?: string;
+      };
+    };
     errors?: GraphQLError[];
   };
 }
@@ -661,6 +666,16 @@ export class BlinkNode implements LightningNode, OnchainPayments {
             message
             path
           }
+          transaction {
+            settlementVia {
+              ... on SettlementViaLn {
+                preImage
+              }
+              ... on SettlementViaIntraLedger {
+                preImage
+              }
+            }
+          }
         }
       }
       `,
@@ -691,9 +706,19 @@ export class BlinkNode implements LightningNode, OnchainPayments {
       );
     }
 
+    const preimage = payment.lnInvoicePaymentSend.transaction?.settlementVia?.preImage ?? '';
+    let paymentHash = '';
+    if (preimage) {
+      try {
+        paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
+      } catch {
+        // The payment succeeded, so preserve the provider result even if the invoice cannot decode.
+      }
+    }
+
     return {
-      paymentHash: '',
-      preimage: '',
+      paymentHash,
+      preimage,
       feeMsats: satsToMsats(feeProbe.lnInvoiceFeeProbe.amount ?? 0),
     };
   }

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -160,6 +160,22 @@ function paymentHashFromInvoice(invoice: string): string {
   }
 }
 
+function isRetryablePaymentReadError(error: unknown): boolean {
+  if (!(error instanceof LniError)) {
+    // Response body reads can reject with a native error rather than LniError.
+    return true;
+  }
+
+  if (error.code === 'NetworkError' || error.code === 'Json') {
+    return true;
+  }
+
+  return (
+    error.code === 'Http' &&
+    (error.status === 404 || (error.status !== undefined && error.status >= 500))
+  );
+}
+
 function normalizeOnchainState(state?: string): PayOnchainResponse['state'] {
   switch (state?.toUpperCase()) {
     case 'PENDING':
@@ -614,9 +630,11 @@ export class StrikeNode implements LightningNode, OnchainPayments {
 
       try {
         payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
-      } catch {
+      } catch (error) {
         // payment.read is optional for payInvoice; without it we still know execution succeeded.
-        break;
+        if (!isRetryablePaymentReadError(error)) {
+          break;
+        }
       }
     }
 

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -73,12 +73,20 @@ interface StrikePaymentQuoteResponse {
   paymentQuoteId: string;
 }
 
+interface StrikeLightningPaymentDetails {
+  paymentHash?: string;
+  paymentRequest?: string;
+  preImage?: string;
+  networkFee?: StrikeAmount;
+}
+
 interface StrikePaymentExecutionResponse {
   paymentId: string;
   state?: string;
   amount?: StrikeAmount;
   totalFee?: StrikeAmount;
   totalAmount?: StrikeAmount;
+  lightning?: StrikeLightningPaymentDetails;
   onchain?: {
     txnId?: string;
   };
@@ -94,12 +102,7 @@ interface StrikePaymentResponse {
   amount: StrikeAmount;
   totalFee?: StrikeAmount;
   totalAmount?: StrikeAmount;
-  lightning?: {
-    paymentHash?: string;
-    paymentRequest?: string;
-    preImage?: string;
-    networkFee?: StrikeAmount;
-  };
+  lightning?: StrikeLightningPaymentDetails;
   onchain?: {
     txnId?: string;
   };
@@ -602,8 +605,8 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       'pay_invoice'
     );
 
-    // The outgoing payment record exposes the proof once the Lightning payment settles.
-    let payment: StrikePaymentResponse | undefined;
+    // Preserve proof returned by execute; otherwise poll the outgoing record until it settles.
+    let payment: StrikePaymentExecutionResponse | StrikePaymentResponse = execution;
     for (let attempt = 0; attempt < 5 && !payment?.lightning?.preImage; attempt += 1) {
       if (attempt > 0) {
         await new Promise((resolve) => setTimeout(resolve, 400));

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -97,6 +97,7 @@ interface StrikePaymentResponse {
   lightning?: {
     paymentHash?: string;
     paymentRequest?: string;
+    preImage?: string;
     networkFee?: StrikeAmount;
   };
   onchain?: {
@@ -600,11 +601,20 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       `/payment-quotes/${quote.paymentQuoteId}/execute`,
       'pay_invoice'
     );
+
+    // The outgoing payment record exposes the proof once the Lightning payment settles.
     let payment: StrikePaymentResponse | undefined;
-    try {
-      payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
-    } catch {
-      // payment.read is optional for payInvoice; without it we still know the payment was executed.
+    for (let attempt = 0; attempt < 5 && !payment?.lightning?.preImage; attempt += 1) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      }
+
+      try {
+        payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
+      } catch {
+        // payment.read is optional for payInvoice; without it we still know execution succeeded.
+        break;
+      }
     }
 
     const feeMsats = payment?.lightning?.networkFee
@@ -613,7 +623,7 @@ export class StrikeNode implements LightningNode, OnchainPayments {
 
     return {
       paymentHash: payment?.lightning?.paymentHash ?? paymentHashFromInvoice(params.invoice),
-      preimage: '',
+      preimage: payment?.lightning?.preImage ?? '',
       feeMsats,
     };
   }

--- a/crates/lni/blink/api.rs
+++ b/crates/lni/blink/api.rs
@@ -538,6 +538,17 @@ pub async fn pay_invoice(
                     path
                     code
                 }
+                transaction {
+                    settlementVia {
+                        __typename
+                        ... on SettlementViaLn {
+                            preImage
+                        }
+                        ... on SettlementViaIntraLedger {
+                            preImage
+                        }
+                    }
+                }
             }
         }
     "#;
@@ -580,10 +591,21 @@ pub async fn pay_invoice(
         Ok(invoice) => format!("{:x}", invoice.payment_hash()),
         Err(_) => "".to_string(),
     };
+    let preimage = match payment_response
+        .ln_invoice_payment_send
+        .transaction
+        .and_then(|transaction| transaction.settlement_via)
+    {
+        Some(SettlementVia::SettlementViaLn { pre_image })
+        | Some(SettlementVia::SettlementViaIntraLedger { pre_image }) => {
+            pre_image.unwrap_or_default()
+        }
+        _ => "".to_string(),
+    };
 
     Ok(PayInvoiceResponse {
         payment_hash,
-        preimage: "".to_string(), // Blink doesn't expose preimage
+        preimage,
         fee_msats,
     })
 }
@@ -873,6 +895,9 @@ pub async fn list_transactions(
                                     ... on SettlementViaLn {
                                         preImage
                                     }
+                                    ... on SettlementViaIntraLedger {
+                                        preImage
+                                    }
                                 }
                             }
                         }
@@ -912,7 +937,10 @@ pub async fn list_transactions(
         };
 
         let preimage = match node.settlement_via {
-            Some(SettlementVia::SettlementViaLn { pre_image }) => pre_image.unwrap_or_default(),
+            Some(SettlementVia::SettlementViaLn { pre_image })
+            | Some(SettlementVia::SettlementViaIntraLedger { pre_image }) => {
+                pre_image.unwrap_or_default()
+            }
             _ => "".to_string(),
         };
 

--- a/crates/lni/blink/lib.rs
+++ b/crates/lni/blink/lib.rs
@@ -338,7 +338,7 @@ mod tests {
             Ok(txns) => {
                 dbg!(&txns);
                 // Validate we can parse transactions
-                assert!(txns.len() >= 0, "Should contain at least zero transactions");
+                assert!(true, "Should be able to list transactions");
             }
             Err(e) => {
                 println!(

--- a/crates/lni/blink/types.rs
+++ b/crates/lni/blink/types.rs
@@ -107,8 +107,15 @@ pub struct LnInvoicePaymentSendResponse {
 #[derive(Debug, Deserialize)]
 pub struct LnInvoicePaymentResult {
     pub status: String, // "SUCCESS", "FAILURE", "PENDING"
+    pub transaction: Option<LnInvoicePaymentTransaction>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LnInvoicePaymentTransaction {
+    #[serde(rename = "settlementVia")]
+    pub settlement_via: Option<SettlementVia>,
 }
 
 // On-chain payment structures
@@ -265,7 +272,10 @@ pub enum SettlementVia {
         transaction_hash: Option<String>,
     },
     #[serde(rename = "SettlementViaIntraLedger")]
-    SettlementViaIntraLedger {},
+    SettlementViaIntraLedger {
+        #[serde(rename = "preImage")]
+        pre_image: Option<String>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -305,4 +315,46 @@ pub struct UserWithTransactions {
 #[derive(Debug, Deserialize)]
 pub struct AccountWithTransactions {
     pub transactions: TransactionConnection,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn send_preimage(settlement_type: &str) -> String {
+        let response: LnInvoicePaymentSendResponse = serde_json::from_value(serde_json::json!({
+            "lnInvoicePaymentSend": {
+                "status": "SUCCESS",
+                "errors": [],
+                "transaction": {
+                    "settlementVia": {
+                        "__typename": settlement_type,
+                        "preImage": "settled-preimage"
+                    }
+                }
+            }
+        }))
+        .expect("payment response should deserialize");
+
+        match response
+            .ln_invoice_payment_send
+            .transaction
+            .and_then(|transaction| transaction.settlement_via)
+        {
+            Some(SettlementVia::SettlementViaLn { pre_image })
+            | Some(SettlementVia::SettlementViaIntraLedger { pre_image }) => {
+                pre_image.unwrap_or_default()
+            }
+            _ => String::new(),
+        }
+    }
+
+    #[test]
+    fn deserializes_ln_and_intra_ledger_send_preimages() {
+        assert_eq!(send_preimage("SettlementViaLn"), "settled-preimage");
+        assert_eq!(
+            send_preimage("SettlementViaIntraLedger"),
+            "settled-preimage"
+        );
+    }
 }

--- a/crates/lni/spark/api.rs
+++ b/crates/lni/spark/api.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use breez_sdk_spark::{
     BreezSdk, EventListener, GetInfoRequest, GetPaymentRequest, ListPaymentsRequest,
@@ -7,6 +8,7 @@ use breez_sdk_spark::{
     ReceivePaymentRequest, SdkEvent, SendPaymentRequest,
 };
 use tokio::sync::RwLock;
+use tokio::time::Instant;
 
 use crate::types::NodeInfo;
 use crate::{
@@ -22,6 +24,9 @@ struct PaymentInfo {
     preimage: String,
     description: String,
 }
+
+const DEFAULT_PAY_INVOICE_TIMEOUT_SECS: u64 = 60;
+const PAY_INVOICE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Extract invoice/hash/preimage/description from Lightning or Spark payment details.
 /// Returns None for non-Lightning/Spark payment types (Deposit, Withdraw, Token, etc.)
@@ -69,6 +74,10 @@ fn extract_payment_info(payment: &breez_sdk_spark::Payment) -> Option<PaymentInf
         }
         _ => None,
     }
+}
+
+fn has_payment_preimage(payment: &breez_sdk_spark::Payment) -> bool {
+    extract_payment_info(payment).is_some_and(|info| !info.preimage.is_empty())
 }
 
 /// Convert a Breez Payment to an LNI Transaction.
@@ -251,26 +260,50 @@ pub async fn pay_invoice(
             reason: e.to_string(),
         })?;
 
-    let (payment_hash, preimage) = match response.payment.details {
-        Some(PaymentDetails::Lightning {
-            payment_hash,
-            preimage,
-            ..
-        }) => (payment_hash, preimage.unwrap_or_default()),
-        Some(PaymentDetails::Spark { htlc_details, .. }) => {
-            if let Some(htlc) = htlc_details {
-                (htlc.payment_hash, htlc.preimage.unwrap_or_default())
-            } else {
-                ("".to_string(), "".to_string())
-            }
+    let mut payment = response.payment;
+    let timeout_secs = invoice_params
+        .timeout_seconds
+        .and_then(|seconds| u64::try_from(seconds).ok())
+        .unwrap_or(DEFAULT_PAY_INVOICE_TIMEOUT_SECS);
+    let timeout = Duration::from_secs(timeout_secs);
+    let started_at = Instant::now();
+
+    while !has_payment_preimage(&payment)
+        && payment.status != PaymentStatus::Failed
+        && started_at.elapsed() < timeout
+    {
+        let remaining = timeout.saturating_sub(started_at.elapsed());
+        tokio::time::sleep(PAY_INVOICE_POLL_INTERVAL.min(remaining)).await;
+
+        if let Ok(response) = sdk
+            .get_payment(GetPaymentRequest {
+                payment_id: payment.id.clone(),
+            })
+            .await
+        {
+            payment = response.payment;
         }
-        _ => ("".to_string(), "".to_string()),
-    };
+    }
+
+    if payment.status == PaymentStatus::Failed {
+        return Err(ApiError::Api {
+            reason: "Spark Lightning payment failed".to_string(),
+        });
+    }
+
+    let payment_info = extract_payment_info(&payment);
+    let payment_hash = payment_info
+        .as_ref()
+        .map(|info| info.payment_hash.clone())
+        .filter(|payment_hash| !payment_hash.is_empty())
+        .or_else(|| extract_payment_hash(&invoice_params.invoice))
+        .unwrap_or_default();
+    let preimage = payment_info.map(|info| info.preimage).unwrap_or_default();
 
     Ok(PayInvoiceResponse {
         payment_hash,
         preimage,
-        fee_msats: (response.payment.fees as i64) * 1000,
+        fee_msats: (payment.fees as i64) * 1000,
     })
 }
 
@@ -586,4 +619,62 @@ fn extract_payment_hash(invoice: &str) -> Option<String> {
     Bolt11Invoice::from_str(invoice)
         .ok()
         .map(|inv| format!("{:x}", inv.payment_hash()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use breez_sdk_spark::{Payment, PaymentMethod, SparkHtlcDetails, SparkHtlcStatus};
+
+    fn payment(details: PaymentDetails) -> Payment {
+        Payment {
+            id: "payment-1".to_string(),
+            payment_type: PaymentType::Send,
+            status: PaymentStatus::Completed,
+            amount: 1,
+            fees: 0,
+            timestamp: 0,
+            method: PaymentMethod::Lightning,
+            details: Some(details),
+        }
+    }
+
+    #[test]
+    fn extracts_lightning_payment_preimage() {
+        let payment = payment(PaymentDetails::Lightning {
+            description: None,
+            preimage: Some("settled-preimage".to_string()),
+            invoice: "invoice".to_string(),
+            payment_hash: "payment-hash".to_string(),
+            destination_pubkey: "destination".to_string(),
+            lnurl_pay_info: None,
+            lnurl_withdraw_info: None,
+            lnurl_receive_metadata: None,
+        });
+
+        let info =
+            extract_payment_info(&payment).expect("Lightning payment should have proof info");
+        assert_eq!(info.payment_hash, "payment-hash");
+        assert_eq!(info.preimage, "settled-preimage");
+        assert!(has_payment_preimage(&payment));
+    }
+
+    #[test]
+    fn extracts_spark_htlc_payment_preimage() {
+        let mut payment = payment(PaymentDetails::Spark {
+            invoice_details: None,
+            htlc_details: Some(SparkHtlcDetails {
+                payment_hash: "payment-hash".to_string(),
+                preimage: Some("settled-preimage".to_string()),
+                expiry_time: 0,
+                status: SparkHtlcStatus::PreimageShared,
+            }),
+        });
+        payment.method = PaymentMethod::Spark;
+
+        let info = extract_payment_info(&payment).expect("Spark HTLC should have proof info");
+        assert_eq!(info.payment_hash, "payment-hash");
+        assert_eq!(info.preimage, "settled-preimage");
+        assert!(has_payment_preimage(&payment));
+    }
 }

--- a/crates/lni/spark/lib.rs
+++ b/crates/lni/spark/lib.rs
@@ -277,9 +277,6 @@ mod tests {
     use dotenv::dotenv;
     use lazy_static::lazy_static;
     use std::env;
-    use std::sync::Once;
-
-    static INIT: Once = Once::new();
 
     lazy_static! {
         static ref MNEMONIC: String = {
@@ -297,6 +294,10 @@ mod tests {
         static ref TEST_PAYMENT_HASH: String = {
             dotenv().ok();
             env::var("SPARK_TEST_PAYMENT_HASH").unwrap_or_default()
+        };
+        static ref TEST_PAYMENT_REQUEST: String = {
+            dotenv().ok();
+            env::var("SPARK_TEST_PAYMENT_REQUEST").unwrap_or_default()
         };
         static ref TEST_RECEIVER_OFFER: String = {
             dotenv().ok();
@@ -396,34 +397,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_pay_invoice() {
-        if should_skip() {
-            println!("Skipping test: SPARK_MNEMONIC or SPARK_API_KEY not set");
+        if should_skip() || TEST_PAYMENT_REQUEST.is_empty() {
+            println!("Skipping test: credentials or SPARK_TEST_PAYMENT_REQUEST not set");
             return;
         }
 
         let node = get_node().await.expect("Failed to connect");
-        // Note: This test requires a valid invoice to pay
-        // For now we'll just test that the function exists and handles errors
-        match node
+        let result = node
             .pay_invoice(PayInvoiceParams {
-                invoice: "lnbc1***".to_string(), // Invalid invoice for testing
+                invoice: TEST_PAYMENT_REQUEST.to_string(),
                 ..Default::default()
             })
-            .await
-        {
-            Ok(txn) => {
-                println!("txn: {:?}", txn);
-                assert!(
-                    !txn.payment_hash.is_empty(),
-                    "Payment hash should not be empty"
-                );
-            }
-            Err(e) => {
-                println!("Expected error for invalid invoice: {:?}", e);
-                // This is expected to fail with an invalid invoice
-            }
-        }
+            .await;
         let _ = node.disconnect().await;
+
+        let payment = result.expect("pay_invoice should pay the configured Spark test invoice");
+        dbg!(&payment);
     }
 
     #[tokio::test]

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -152,6 +152,10 @@ fn amount_to_sats(amount: Option<&Amount>) -> Option<i64> {
         .map(|btc| (btc * 100_000_000.0).round() as i64)
 }
 
+fn is_retryable_payment_read_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::NOT_FOUND || status.is_server_error()
+}
+
 fn assert_valid_guardrail_limit(value: f64, name: &str) -> Result<(), ApiError> {
     if !value.is_finite() || value < 0.0 {
         return Err(ApiError::InvalidInput(format!(
@@ -511,16 +515,22 @@ pub async fn pay_invoice(
         }
 
         let response = match client.get(&payment_url).send().await {
-            Ok(response) if response.status().is_success() => response,
-            _ => break,
+            Ok(response) => response,
+            Err(_) => continue,
         };
+        if !response.status().is_success() {
+            if is_retryable_payment_read_status(response.status()) {
+                continue;
+            }
+            break;
+        }
         let payment_text = match response.text().await {
             Ok(payment_text) => payment_text,
-            Err(_) => break,
+            Err(_) => continue,
         };
         let parsed = match serde_json::from_str::<PaymentExecutionResponse>(&payment_text) {
             Ok(parsed) => parsed,
-            Err(_) => break,
+            Err(_) => continue,
         };
         payment = Some(parsed);
     }
@@ -1344,6 +1354,19 @@ mod tests {
             }
             other => panic!("expected structured NWC error, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn classifies_retryable_payment_read_statuses() {
+        assert!(is_retryable_payment_read_status(
+            reqwest::StatusCode::NOT_FOUND
+        ));
+        assert!(is_retryable_payment_read_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+        assert!(!is_retryable_payment_read_status(
+            reqwest::StatusCode::UNAUTHORIZED
+        ));
     }
 
     #[test]

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -489,52 +489,72 @@ pub async fn pay_invoice(
     let execute_text = execute_response.text().await.unwrap();
     let execute_resp: PaymentExecutionResponse = serde_json::from_str(&execute_text)?;
 
-    // Get payment details
-    let payment_id = &execute_resp.payment_id;
-
+    // Get the outgoing payment record. The Lightning proof can appear shortly after execution.
+    let payment_id = execute_resp.payment_id.clone();
     let payment_url = format!("{}/payments/{}", get_base_url(&config), payment_id);
-    let payment_response = client
-        .get(&payment_url)
-        .send()
-        .await
-        .map_err(|e| strike_nwc_error_from_transport(e, "pay_invoice"))?;
+    let mut payment = Some(execute_resp);
 
-    if !payment_response.status().is_success() {
-        let status = payment_response.status();
-        let error_text = payment_response.text().await.unwrap_or_default();
-        return Err(strike_nwc_error_from_response(
-            status,
-            error_text,
-            "pay_invoice",
-            "Failed to get payment details",
-        ));
+    for attempt in 0..5 {
+        let has_preimage = matches!(
+            payment
+                .as_ref()
+                .and_then(|payment| payment.lightning.as_ref())
+                .and_then(|lightning| lightning.pre_image.as_deref()),
+            Some(preimage) if !preimage.is_empty()
+        );
+        if has_preimage {
+            break;
+        }
+
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(400)).await;
+        }
+
+        let response = match client.get(&payment_url).send().await {
+            Ok(response) if response.status().is_success() => response,
+            _ => break,
+        };
+        let payment_text = match response.text().await {
+            Ok(payment_text) => payment_text,
+            Err(_) => break,
+        };
+        let parsed = match serde_json::from_str::<PaymentExecutionResponse>(&payment_text) {
+            Ok(parsed) => parsed,
+            Err(_) => break,
+        };
+        payment = Some(parsed);
     }
 
-    let payment_text = payment_response.text().await.unwrap();
-    let payment_resp: PaymentExecutionResponse = serde_json::from_str(&payment_text)?;
-
-    let fee_msats = if let Some(lightning) = &payment_resp.lightning {
-        let fee_amount = lightning.network_fee.amount.parse::<f64>().unwrap_or(0.0);
-        if lightning.network_fee.currency == "BTC" {
-            (fee_amount * 100_000_000_000.0) as i64
-        } else {
-            0
-        }
-    } else {
-        0
-    };
+    let fee_msats = payment
+        .as_ref()
+        .and_then(|payment| payment.lightning.as_ref())
+        .and_then(|lightning| lightning.network_fee.as_ref())
+        .or_else(|| {
+            payment
+                .as_ref()
+                .and_then(|payment| payment.lightning_network_fee.as_ref())
+        })
+        .filter(|fee| fee.currency == "BTC")
+        .and_then(|fee| fee.amount.parse::<f64>().ok())
+        .map(|fee| (fee * 100_000_000_000.0) as i64)
+        .unwrap_or(0);
 
     // Extract payment hash from the original BOLT11 invoice
-    let payment_hash = match Bolt11Invoice::from_str(&invoice_params.invoice) {
+    let invoice_payment_hash = match Bolt11Invoice::from_str(&invoice_params.invoice) {
         Ok(invoice) => {
             format!("{:x}", invoice.payment_hash())
         }
         Err(_) => "".to_string(), // If parsing fails, return empty string
     };
+    let preimage = payment
+        .as_ref()
+        .and_then(|payment| payment.lightning.as_ref())
+        .and_then(|lightning| lightning.pre_image.clone())
+        .unwrap_or_default();
 
     Ok(PayInvoiceResponse {
-        payment_hash,             // Extract from BOLT11 invoice
-        preimage: "".to_string(), // Strike doesn't expose preimage
+        payment_hash: invoice_payment_hash,
+        preimage,
         fee_msats,
     })
 }
@@ -1126,7 +1146,11 @@ pub async fn list_transactions(
                     .as_ref()
                     .and_then(|l| l.payment_request.clone())
                     .unwrap_or_default(),
-                preimage: "".to_string(),
+                preimage: payment
+                    .lightning
+                    .as_ref()
+                    .and_then(|lightning| lightning.pre_image.clone())
+                    .unwrap_or_default(),
                 payment_hash: payment
                     .lightning
                     .as_ref()

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -196,8 +196,8 @@ mod tests {
     };
     use dotenv::dotenv;
     use lazy_static::lazy_static;
-    use std::env;
     use std::sync::{Arc, Mutex};
+    use std::{dbg, env};
 
     const ONCHAIN_SEND_CONFIRMATION: &str = "I_UNDERSTAND_THIS_BROADCASTS_BITCOIN";
 
@@ -275,24 +275,28 @@ mod tests {
         }
     }
 
-    // #[tokio::test]
-    // async fn test_pay_invoice() {
-    //     match NODE.pay_invoice(PayInvoiceParams {
-    //         invoice: TEST_PAYMENT_REQUEST.to_string(),
-    //         ..Default::default()
-    //     }).await {
-    //         Ok(invoice_resp) => {
-    //             println!("Strike pay invoice resp: {:?}", invoice_resp);
-    //         }
-    //         Err(e) => {
-    //             println!(
-    //                 "Strike pay invoice failed (expected if no API key or invalid invoice): {:?}",
-    //                 e
-    //             );
-    //             // Don't panic as this requires valid API key and invoice
-    //         }
-    //     }
-    // }
+    #[tokio::test]
+    async fn test_pay_invoice() {
+        match NODE
+            .pay_invoice(PayInvoiceParams {
+                invoice: TEST_PAYMENT_REQUEST.to_string(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(invoice_resp) => {
+                dbg!("Strike pay invoice resp: {:?}", &invoice_resp);
+                println!("Strike pay invoice resp: {:?}", invoice_resp);
+            }
+            Err(e) => {
+                println!(
+                    "Strike pay invoice failed (expected if no API key or invalid invoice): {:?}",
+                    e
+                );
+                // Don't panic as this requires valid API key and invoice
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_lookup_invoice() {
@@ -335,6 +339,7 @@ mod tests {
         };
         match NODE.list_transactions(params).await {
             Ok(txns) => {
+                dbg!("Strike list transactions: {:?}", &txns);
                 println!("Strike transactions: {:?}", txns);
                 assert!(true, "Should be able to list transactions");
             }

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -276,6 +276,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "pays a real Lightning invoice"]
     async fn test_pay_invoice() {
         match NODE
             .pay_invoice(PayInvoiceParams {
@@ -285,8 +286,12 @@ mod tests {
             .await
         {
             Ok(invoice_resp) => {
-                dbg!("Strike pay invoice resp: {:?}", &invoice_resp);
-                println!("Strike pay invoice resp: {:?}", invoice_resp);
+                println!(
+                    "Strike pay_invoice succeeded: payment_hash_present={}, preimage_present={}, fee_msats={}",
+                    !invoice_resp.payment_hash.is_empty(),
+                    !invoice_resp.preimage.is_empty(),
+                    invoice_resp.fee_msats
+                );
             }
             Err(e) => {
                 println!(

--- a/crates/lni/strike/types.rs
+++ b/crates/lni/strike/types.rs
@@ -132,9 +132,14 @@ pub struct Payment {
 
 #[derive(Debug, Deserialize)]
 pub struct LightningPayment {
+    #[serde(rename = "networkFee")]
     pub network_fee: Option<Amount>,
+    #[serde(rename = "paymentHash")]
     pub payment_hash: Option<String>,
+    #[serde(rename = "paymentRequest")]
     pub payment_request: Option<String>,
+    #[serde(rename = "preImage")]
+    pub pre_image: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -189,7 +194,9 @@ pub struct PaymentQuoteResponse {
 #[derive(Debug, Deserialize)]
 pub struct LightningDetails {
     #[serde(rename = "networkFee")]
-    pub network_fee: Amount,
+    pub network_fee: Option<Amount>,
+    #[serde(rename = "preImage")]
+    pub pre_image: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -197,14 +204,14 @@ pub struct PaymentExecutionResponse {
     #[serde(rename = "paymentId")]
     pub payment_id: String,
     pub state: String,
-    pub result: String,
+    pub result: Option<String>,
     pub completed: Option<String>,
     pub delivered: Option<String>,
     pub amount: Amount,
     #[serde(rename = "totalFee")]
-    pub total_fee: Amount,
+    pub total_fee: Option<Amount>,
     #[serde(rename = "lightningNetworkFee")]
-    pub lightning_network_fee: Amount,
+    pub lightning_network_fee: Option<Amount>,
     #[serde(rename = "totalAmount")]
     pub total_amount: Amount,
     pub lightning: Option<LightningDetails>,
@@ -500,4 +507,38 @@ pub struct ReceiveRequestResponse {
 pub struct ReceiveRequestsResponse {
     pub data: Vec<ReceiveRequest>,
     pub count: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_payment_detail_lightning_proof() {
+        let payment: PaymentExecutionResponse = serde_json::from_str(
+            r#"{
+                "paymentId": "payment-1",
+                "amount": { "amount": "0.00002500", "currency": "BTC" },
+                "totalAmount": { "amount": "0.00002501", "currency": "BTC" },
+                "state": "COMPLETED",
+                "lightning": {
+                    "networkFee": { "amount": "0.00000001", "currency": "BTC" },
+                    "preImage": "settled-preimage"
+                }
+            }"#,
+        )
+        .expect("payment record should deserialize");
+
+        let lightning = payment
+            .lightning
+            .expect("lightning details should be present");
+        assert_eq!(lightning.pre_image.as_deref(), Some("settled-preimage"));
+        assert_eq!(
+            lightning
+                .network_fee
+                .as_ref()
+                .map(|fee| fee.amount.as_str()),
+            Some("0.00000001")
+        );
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,25 @@ For Strike, LNI maps `fast` to `tier_fast`, `normal` to `tier_standard`, and `sl
 
 For Blink, LNI maps `fast`, `normal`, and `slow` to Blink's `FAST`, `MEDIUM`, and `SLOW` payout speeds. Blink does not support `free`, target-confirmation, sats/vbyte, backend fee preferences, or recipient-paid fees for on-chain sends.
 
+Testing Lightning invoice payments
+----------------------------------
+
+Blink's TypeScript integration test can execute a real Lightning payment and verify that the returned preimage hashes to the payment hash. Add a fresh, unpaid invoice from another wallet to `crates/lni/.env`:
+
+```env
+BLINK_API_KEY=...
+BLINK_TEST_PAYMENT_REQUEST=lnbc...
+```
+
+Run only the live payment test:
+
+```bash
+cd bindings/typescript
+npm run test:integration:blink -- -t "payInvoice returns a valid Lightning preimage"
+```
+
+The test runs whenever both values are present. It pays the invoice and spends funds from the configured Blink account; remove or comment out the test after use if you do not want it included in later Blink integration runs.
+
 Testing on-chain payments
 -------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Lightning invoice payments across Blink, Spark, and Strike now return the confirmed payment hash and preimage.
  - Payment flows wait/poll for settlement details before completing, improving reliability and fee reporting.
  - Transaction history now includes preimages for supported Lightning and intra-ledger settlements.
  - Strike now reports more accurate network fee information.
- **Documentation**
  - Added instructions for running live Lightning invoice payment tests and required environment variables.
- **Tests**
  - Expanded unit and integration coverage for preimage/hash verification (including real-payment tests behind env flags).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->