### PR TITLE
fix(strike, blink): surface the payment preimage from payInvoice

### DIFF
--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -1,5 +1,5 @@
 import { LniError, NwcError, type NwcErrorCode, type NwcErrorOperation } from '../errors.js';
-import { decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
+import { decode as decodeBolt11, decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
 import {
   mapProviderMessage,
   throwNormalizedProviderError,
@@ -89,6 +89,11 @@ interface BlinkPaymentSendResponse {
   lnInvoicePaymentSend: {
     status: string;
     errors?: GraphQLError[];
+    transaction?: {
+      settlementVia?: {
+        preImage?: string;
+      };
+    };
   };
 }
 
@@ -661,6 +666,16 @@ export class BlinkNode implements LightningNode, OnchainPayments {
             message
             path
           }
+          transaction {
+            settlementVia {
+              ... on SettlementViaLn {
+                preImage
+              }
+              ... on SettlementViaIntraLedger {
+                preImage
+              }
+            }
+          }
         }
       }
       `,
@@ -691,9 +706,21 @@ export class BlinkNode implements LightningNode, OnchainPayments {
       );
     }
 
+    // The proof of payment: SettlementViaLn and SettlementViaIntraLedger
+    // (payer and payee both on Blink) each expose the settled pre-image.
+    const preimage = payment.lnInvoicePaymentSend.transaction?.settlementVia?.preImage ?? '';
+    let paymentHash = '';
+    if (preimage) {
+      try {
+        paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
+      } catch {
+        paymentHash = '';
+      }
+    }
+
     return {
-      paymentHash: '',
-      preimage: '',
+      paymentHash,
+      preimage,
       feeMsats: satsToMsats(feeProbe.lnInvoiceFeeProbe.amount ?? 0),
     };
   }

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -98,6 +98,7 @@ interface StrikePaymentResponse {
     paymentHash?: string;
     paymentRequest?: string;
     networkFee?: StrikeAmount;
+    preImage?: string;
   };
   onchain?: {
     txnId?: string;
@@ -601,10 +602,19 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       'pay_invoice'
     );
     let payment: StrikePaymentResponse | undefined;
-    try {
-      payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
-    } catch {
-      // payment.read is optional for payInvoice; without it we still know the payment was executed.
+    // The pre-image appears on the payment record once it settles (usually
+    // immediately for Lightning) — poll the read briefly to capture the
+    // proof of payment.
+    for (let attempt = 0; attempt < 5 && !payment?.lightning?.preImage; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      }
+      try {
+        payment = await this.getJson<StrikePaymentResponse>(`/payments/${execution.paymentId}`);
+      } catch {
+        // payment.read is optional for payInvoice; without it we still know the payment was executed.
+        break;
+      }
     }
 
     const feeMsats = payment?.lightning?.networkFee
@@ -613,7 +623,7 @@ export class StrikeNode implements LightningNode, OnchainPayments {
 
     return {
       paymentHash: payment?.lightning?.paymentHash ?? paymentHashFromInvoice(params.invoice),
-      preimage: '',
+      preimage: payment?.lightning?.preImage ?? '',
       feeMsats,
     };
   }


### PR DESCRIPTION
## Summary

`payInvoice` returns empty proof fields for Strike and Blink even though both providers expose the preimage:

- **Strike**: `payInvoice` already fetches `/v1/payments/{paymentId}` (for the network fee) — that response also documents `lightning.preImage` ("The pre-image of the payment, if available"), but the method returned `preimage: ''`. This PR reads the field, polling the payment read briefly (up to 5 attempts, 400 ms apart) since the pre-image lands when the payment settles — usually immediately for Lightning. Callers whose API key lacks the optional `payment.read` scope keep today's behavior.
- **Blink**: `lnInvoicePaymentSend` returns a `PaymentSendPayload` whose `transaction.settlementVia` carries `preImage` on both `SettlementViaLn` and `SettlementViaIntraLedger` (payer and payee on the same instance). This PR expands the mutation selection to include it and derives `paymentHash` from the invoice when a preimage is present, mirroring Strike's `paymentHashFromInvoice` approach.

## Why

Consumers using `payInvoice`'s result as cryptographic proof of payment (`sha256(preimage) === invoice payment hash`) currently only receive proof from NWC nodes. Worse, a caller that treats "no proof" as "fall back to `onInvoiceEvents`" hangs forever on Strike: its `lookupInvoice` queries `/receive-requests/receives` — the receive side — where an outgoing payment never appears, so the poll can never confirm a payment the account *made*.

## References

- Strike Payment object (`lightning.preImage`): https://docs.strike.me/api/get-payment-by-id/
- Blink/Galoy public schema (`PaymentSendPayload.transaction`, `SettlementViaLn.preImage`, `SettlementViaIntraLedger.preImage`): https://github.com/GaloyMoney/blink/blob/main/core/api/src/graphql/public/schema.graphql

## Testing

- `npm run build` (tsc) clean; `npm test` — 69 passed, 19 skipped (live-API suites).
- The same change has been running as a pnpm patch against the compiled dist of `@sunnyln/lni@0.2.15` in ZapriteApp/ZapriteP2P#592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)