### PR TITLE
Fee Limits and FeeError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ This file defines stable, repository-level guidance for future coding agents.
   - Reuse helpers from `bindings/typescript/src/internal/*`.
   - Export from `bindings/typescript/src/index.ts`.
 
+## Shared Helper Guidance
+- Reuse or add shared Rust calculation, conversion, and validation helpers in:
+  - `crates/lni/utils.rs`
+- Reuse or add the corresponding TypeScript helpers in:
+  - `bindings/typescript/src/internal/transform.ts`
+- Keep helper semantics consistent across Rust and TypeScript, and avoid duplicating
+  reusable helpers inside individual node adapters.
+
 ## Test/Validation Expectations
 - Prefer real integration-style tests over mocks for node adapters.
 - Add/maintain node-specific integration tests under:

--- a/bindings/typescript/README.md
+++ b/bindings/typescript/README.md
@@ -58,6 +58,28 @@ const status = await node.lookupInvoice({ paymentHash: invoice.paymentHash });
 const txs = await node.listTransactions({ from: 0, limit: 10 });
 ```
 
+`StrikeNode.payInvoice` supports `feeLimitMsat` and `feeLimitPercentage`. Strike does not
+accept a maximum fee in the payment request, so LNI enforces the configured limit by
+validating the returned Lightning quote before executing it. Percentage limits use the
+payment amount before fees, and no fee limit is applied when neither field is provided.
+When a valid quote exceeds the configured limit, `payInvoice` throws a `FeeError` before
+execution. Its friendly message displays exact sat amounts and explains which
+`feeLimitMsat` or `feeLimitPercentage` setting can be increased to allow the payment.
+Invalid limit configuration or an unsafe/malformed quote remains an `InvalidInput`
+`LniError`.
+
+```ts
+import { FeeError } from '@sunnyln/lni';
+
+try {
+  await node.payInvoice({ invoice: invoice.invoice, feeLimitMsat: 1_000 });
+} catch (error) {
+  if (error instanceof FeeError) {
+    console.error(error.message);
+  }
+}
+```
+
 ### On-chain Bitcoin Payments
 
 On-chain payments use a prepare-then-pay flow so apps can show fees before executing a payment. This is currently implemented for `StrikeNode` and `BlinkNode`.

--- a/bindings/typescript/README.md
+++ b/bindings/typescript/README.md
@@ -62,6 +62,8 @@ const txs = await node.listTransactions({ from: 0, limit: 10 });
 accept a maximum fee in the payment request, so LNI enforces the configured limit by
 validating the returned Lightning quote before executing it. Percentage limits use the
 payment amount before fees, and no fee limit is applied when neither field is provided.
+When Strike returns both `totalFee` and `lightningNetworkFee`, LNI enforces `totalFee`
+because it represents the complete quoted fee.
 When a valid quote exceeds the configured limit, `payInvoice` throws a `FeeError` before
 execution. Its friendly message displays exact sat amounts and explains which
 `feeLimitMsat` or `feeLimitPercentage` setting can be increased to allow the payment.

--- a/bindings/typescript/src/__tests__/exports.test.ts
+++ b/bindings/typescript/src/__tests__/exports.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { decode, decodeOffer } from '../index.js';
+import { decode, decodeOffer, FeeError } from '../index.js';
 
 describe('public exports', () => {
   it('exports BOLT11 decode from the package root', () => {
@@ -8,5 +8,15 @@ describe('public exports', () => {
 
   it('exports BOLT12 offer decode from the package root', () => {
     expect(typeof decodeOffer).toBe('function');
+  });
+
+  it('exports FeeError from the package root', () => {
+    const error = new FeeError('quoted fee exceeded the configured limit');
+
+    expect(error).toMatchObject({
+      name: 'FeeError',
+      code: 'FeeError',
+      message: 'quoted fee exceeded the configured limit',
+    });
   });
 });

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { NwcError } from '../errors.js';
+import { FeeError, NwcError } from '../errors.js';
+import { formatMsatsAsSats } from '../internal/transform.js';
 import { StrikeNode } from '../nodes/strike.js';
 import type { FetchLike } from '../types.js';
 
@@ -133,6 +134,217 @@ describe('StrikeNode error normalization', () => {
 });
 
 describe('StrikeNode Lightning payments', () => {
+  function makeQuoteNode(quote: Record<string, unknown>) {
+    const fetchMock = vi.fn<FetchLike>(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://api.strike.test/v1/payment-quotes/lightning') {
+        return jsonResponse({ paymentQuoteId: 'quote-1', ...quote });
+      }
+
+      if (url === 'https://api.strike.test/v1/payment-quotes/quote-1/execute') {
+        return jsonResponse({
+          paymentId: 'payment-1',
+          lightning: {
+            preImage: 'execute-preimage',
+            networkFee: { amount: '0', currency: 'BTC' },
+          },
+        });
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    return {
+      fetchMock,
+      node: new StrikeNode(
+        { apiKey: 'test-token', baseUrl: 'https://api.strike.test/v1' },
+        { fetch: fetchMock }
+      ),
+    };
+  }
+
+  it.each([
+    {
+      relation: 'below',
+      quote: {
+        lightningNetworkFee: { amount: '0.00000000999', currency: 'BTC' },
+      },
+      limit: 1_000,
+      executes: true,
+    },
+    {
+      relation: 'equal to',
+      quote: {
+        totalFee: { amount: '0.00000001000', currency: 'BTC' },
+      },
+      limit: 1_000,
+      executes: true,
+    },
+    {
+      relation: 'above',
+      quote: {
+        lightningNetworkFee: { amount: '0.00000001001', currency: 'BTC' },
+      },
+      limit: 1_000,
+      executes: false,
+    },
+  ])('$relation feeLimitMsat is enforced before execution', async ({ quote, limit, executes }) => {
+    const { fetchMock, node } = makeQuoteNode(quote);
+    const payment = node.payInvoice({ invoice: BOLT11, feeLimitMsat: limit });
+
+    if (executes) {
+      await expect(payment).resolves.toMatchObject({ preimage: 'execute-preimage' });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } else {
+      await expect(payment).rejects.toMatchObject({
+        name: 'FeeError',
+        code: 'FeeError',
+        message:
+          'Payment not sent: Strike quoted a Lightning fee of 1.001 sats, which is higher than your configured fee limit of 1 sat. Set feeLimitMsat to at least 1001 (1.001 sats) to allow this payment.',
+      });
+      await expect(payment).rejects.toBeInstanceOf(FeeError);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it.each([
+    { relation: 'below', limit: 1.01, executes: true },
+    { relation: 'equal to', limit: 1, executes: true },
+    { relation: 'above', limit: 0.99, executes: false },
+  ])(
+    '$relation feeLimitPercentage is enforced against the payment amount',
+    async ({ limit, executes }) => {
+      const { fetchMock, node } = makeQuoteNode({
+        amount: { amount: '0.00001000', currency: 'BTC' },
+        lightningNetworkFee: { amount: '0.00000010', currency: 'BTC' },
+      });
+      const payment = node.payInvoice({
+        invoice: BOLT11,
+        feeLimitPercentage: limit,
+      });
+
+      if (executes) {
+        await expect(payment).resolves.toMatchObject({ preimage: 'execute-preimage' });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      } else {
+        await expect(payment).rejects.toMatchObject({
+          name: 'FeeError',
+          code: 'FeeError',
+          message:
+            'Payment not sent: Strike quoted a Lightning fee of 10 sats for a payment amount of 1000 sats, which is higher than your feeLimitPercentage of 0.99%. Increase feeLimitPercentage or set feeLimitMsat to at least 10000 (10 sats) to allow this payment.',
+        });
+        await expect(payment).rejects.toBeInstanceOf(FeeError);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      }
+    }
+  );
+
+  it('allows a fee-free direct Strike quote when amount and totalAmount are equal', async () => {
+    const { fetchMock, node } = makeQuoteNode({
+      amount: { amount: '0.00001000', currency: 'BTC' },
+      totalAmount: { amount: '0.00001000', currency: 'BTC' },
+    });
+
+    await expect(node.payInvoice({ invoice: BOLT11, feeLimitMsat: 0 })).resolves.toMatchObject({
+      preimage: 'execute-preimage',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects both fee limit forms before creating a quote', async () => {
+    const { fetchMock, node } = makeQuoteNode({});
+
+    await expect(
+      node.payInvoice({
+        invoice: BOLT11,
+        feeLimitMsat: 1_000,
+        feeLimitPercentage: 1,
+      })
+    ).rejects.toMatchObject({
+      code: 'InvalidInput',
+      message: 'Cannot set both feeLimitMsat and feeLimitPercentage.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['negative absolute limit', { feeLimitMsat: -1 }],
+    ['fractional absolute limit', { feeLimitMsat: 0.5 }],
+    ['non-finite absolute limit', { feeLimitMsat: Number.POSITIVE_INFINITY }],
+    ['unsafe absolute limit', { feeLimitMsat: Number.MAX_SAFE_INTEGER + 1 }],
+    ['negative percentage limit', { feeLimitPercentage: -0.1 }],
+    ['non-finite percentage limit', { feeLimitPercentage: Number.NaN }],
+    ['unsafe percentage limit', { feeLimitPercentage: Number.MAX_SAFE_INTEGER + 1 }],
+  ])('rejects an invalid %s', async (_name, limit) => {
+    const { fetchMock, node } = makeQuoteNode({});
+
+    await expect(node.payInvoice({ invoice: BOLT11, ...limit })).rejects.toMatchObject({
+      code: 'InvalidInput',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing', {}],
+    [
+      'malformed',
+      {
+        lightningNetworkFee: { amount: '0.000000010005', currency: 'BTC' },
+      },
+    ],
+    [
+      'non-BTC',
+      {
+        totalFee: { amount: '0.00000001', currency: 'USD' },
+      },
+    ],
+  ])('fails closed when a limited quote fee is %s', async (_shape, quote) => {
+    const { fetchMock, node } = makeQuoteNode(quote);
+
+    await expect(node.payInvoice({ invoice: BOLT11, feeLimitMsat: 1_000 })).rejects.toMatchObject({
+      code: 'InvalidInput',
+      message:
+        'Cannot enforce feeLimitMsat 1000 msats because the Strike quote fee could not be determined safely.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when a percentage-limited quote payment amount is missing', async () => {
+    const { fetchMock, node } = makeQuoteNode({
+      lightningNetworkFee: { amount: '0.00000001', currency: 'BTC' },
+    });
+
+    await expect(node.payInvoice({ invoice: BOLT11, feeLimitPercentage: 1 })).rejects.toMatchObject(
+      {
+        code: 'InvalidInput',
+        message:
+          'Cannot enforce feeLimitPercentage 1% because the Strike quote payment amount could not be determined safely.',
+      }
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves execution behavior when neither fee limit is supplied', async () => {
+    const { fetchMock, node } = makeQuoteNode({
+      lightningNetworkFee: { amount: 'malformed', currency: 'BTC' },
+    });
+
+    await expect(node.payInvoice({ invoice: BOLT11 })).resolves.toMatchObject({
+      preimage: 'execute-preimage',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [0n, '0 sats'],
+    [1_000n, '1 sat'],
+    [1_001n, '1.001 sats'],
+    [4_000n, '4 sats'],
+  ])('formats %s msats as exact sats in fee errors', (msats, expected) => {
+    expect(formatMsatsAsSats(msats)).toBe(expected);
+  });
+
   it('preserves a preimage returned by execute when payment.read is unavailable', async () => {
     const fetchMock = vi.fn<FetchLike>(async (input) => {
       const url = String(input);

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -208,6 +208,21 @@ describe('StrikeNode Lightning payments', () => {
     }
   });
 
+  it('enforces totalFee when both quoted fee fields differ', async () => {
+    const { fetchMock, node } = makeQuoteNode({
+      lightningNetworkFee: { amount: '0.00000001', currency: 'BTC' },
+      totalFee: { amount: '0.00000100', currency: 'BTC' },
+    });
+
+    await expect(node.payInvoice({ invoice: BOLT11, feeLimitMsat: 2_000 })).rejects.toMatchObject({
+      name: 'FeeError',
+      code: 'FeeError',
+      message:
+        'Payment not sent: Strike quoted a Lightning fee of 100 sats, which is higher than your configured fee limit of 2 sats. Set feeLimitMsat to at least 100000 (100 sats) to allow this payment.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     { relation: 'below', limit: 1.01, executes: true },
     { relation: 'equal to', limit: 1, executes: true },
@@ -291,6 +306,13 @@ describe('StrikeNode Lightning payments', () => {
       'malformed',
       {
         lightningNetworkFee: { amount: '0.000000010005', currency: 'BTC' },
+      },
+    ],
+    [
+      'malformed total with a valid network component',
+      {
+        lightningNetworkFee: { amount: '0.00000001', currency: 'BTC' },
+        totalFee: { amount: 'malformed', currency: 'BTC' },
       },
     ],
     [

--- a/bindings/typescript/src/errors.ts
+++ b/bindings/typescript/src/errors.ts
@@ -4,6 +4,7 @@ export type LniErrorCode =
   | 'Json'
   | 'NetworkError'
   | 'InvalidInput'
+  | 'FeeError'
   | 'LnurlError'
   | 'NwcError';
 
@@ -45,6 +46,20 @@ export class LniError extends Error {
     this.code = code;
     this.status = options?.status;
     this.body = options?.body;
+  }
+}
+
+/**
+ * A valid quoted or provider fee exceeded a caller-configured fee limit.
+ *
+ * This is a local LNI guardrail error: the payment was not executed. Invalid
+ * fee-limit configuration and quotes whose fee cannot be determined safely
+ * continue to use `LniError` with the `InvalidInput` code.
+ */
+export class FeeError extends LniError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('FeeError', message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = 'FeeError';
   }
 }
 

--- a/bindings/typescript/src/internal/transform.ts
+++ b/bindings/typescript/src/internal/transform.ts
@@ -75,12 +75,51 @@ export function rHashToHex(value: string): string {
   }
 }
 
+const MSATS_PER_BTC = 100_000_000_000n;
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+
+export function parseBtcToMsatsExact(amount: string): bigint | undefined {
+  const match = /^(\d+)(?:\.(\d+))?$/.exec(amount);
+  if (!match) {
+    return undefined;
+  }
+
+  const fraction = match[2] ?? '';
+  if (fraction.length > 11 && /[1-9]/.test(fraction.slice(11))) {
+    return undefined;
+  }
+
+  const wholeMsats = BigInt(match[1]!) * MSATS_PER_BTC;
+  const fractionalMsats = BigInt((fraction.slice(0, 11) + '0'.repeat(11)).slice(0, 11));
+  const msats = wholeMsats + fractionalMsats;
+  return msats <= MAX_SAFE_INTEGER_BIGINT ? msats : undefined;
+}
+
+export function formatMsatsAsSats(amountMsats: bigint): string {
+  const isNegative = amountMsats < 0n;
+  const absoluteMsats = isNegative ? -amountMsats : amountMsats;
+  const wholeSats = absoluteMsats / 1_000n;
+  const fractionalMsats = absoluteMsats % 1_000n;
+  const sign = isNegative ? '-' : '';
+  const amount =
+    fractionalMsats === 0n
+      ? `${sign}${wholeSats}`
+      : `${sign}${wholeSats}.${fractionalMsats.toString().padStart(3, '0').replace(/0+$/, '')}`;
+  const unit = absoluteMsats === 1_000n ? 'sat' : 'sats';
+
+  return `${amount} ${unit}`;
+}
+
 export function btcToMsats(amount: string | number): number {
-  const num = typeof amount === 'string' ? Number(amount) : amount;
-  if (!Number.isFinite(num)) {
+  if (typeof amount === 'string') {
+    const msats = parseBtcToMsatsExact(amount);
+    return msats === undefined ? 0 : Number(msats);
+  }
+
+  if (!Number.isFinite(amount)) {
     return 0;
   }
-  return Math.round(num * 100_000_000_000);
+  return Math.round(amount * 100_000_000_000);
 }
 
 export function msatsToBtc(amountMsats: number): string {

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -1,5 +1,11 @@
 import { decode as decodeBolt11, decodeBolt11ToJson, decodeOfferToJson } from '../decode.js';
-import { LniError, NwcError, type NwcErrorCode, type NwcErrorOperation } from '../errors.js';
+import {
+  FeeError,
+  LniError,
+  NwcError,
+  type NwcErrorCode,
+  type NwcErrorOperation,
+} from '../errors.js';
 import {
   findStringProperty,
   providerInfoFromJsonErrorBody,
@@ -13,8 +19,10 @@ import {
   btcToMsats,
   emptyNodeInfo,
   emptyTransaction,
+  formatMsatsAsSats,
   matchesSearch,
   msatsToBtc,
+  parseBtcToMsatsExact,
   parseOptionalNumber,
   toUnixSeconds,
 } from '../internal/transform.js';
@@ -71,6 +79,10 @@ interface StrikeCreateReceiveResponse {
 
 interface StrikePaymentQuoteResponse {
   paymentQuoteId: string;
+  lightningNetworkFee?: StrikeAmount;
+  amount?: StrikeAmount;
+  totalFee?: StrikeAmount;
+  totalAmount?: StrikeAmount;
 }
 
 interface StrikeLightningPaymentDetails {
@@ -206,6 +218,133 @@ function onchainAmountToSats(amount?: StrikeAmount): number | undefined {
 
   const btc = Number.parseFloat(amount.amount);
   return Number.isFinite(btc) ? Math.round(btc * 100_000_000) : undefined;
+}
+
+function strikeBtcAmountToMsats(amount: unknown): bigint | undefined {
+  if (!isRecord(amount) || amount.currency !== 'BTC' || typeof amount.amount !== 'string') {
+    return undefined;
+  }
+
+  return parseBtcToMsatsExact(amount.amount);
+}
+
+function strikeQuoteFeeMsats(quote: StrikePaymentQuoteResponse): bigint | undefined {
+  let hasQuotedFee = false;
+  for (const fee of [quote.lightningNetworkFee, quote.totalFee]) {
+    if (fee !== undefined && fee !== null) {
+      hasQuotedFee = true;
+      const feeMsats = strikeBtcAmountToMsats(fee);
+      if (feeMsats !== undefined) {
+        return feeMsats;
+      }
+    }
+  }
+
+  if (hasQuotedFee) {
+    return undefined;
+  }
+
+  // Strike-to-Strike/direct quotes can omit fee properties. The quote is provably
+  // fee-free when the sender's total and the recipient amount are identical.
+  const amountMsats = strikeBtcAmountToMsats(quote.amount);
+  const totalAmountMsats = strikeBtcAmountToMsats(quote.totalAmount);
+  if (amountMsats !== undefined && totalAmountMsats === amountMsats) {
+    return 0n;
+  }
+
+  return undefined;
+}
+
+function decimalNumberToFraction(value: number): { numerator: bigint; denominator: bigint } {
+  const match = /^(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/.exec(value.toString().toLowerCase());
+  if (!match) {
+    throw new LniError('InvalidInput', 'feeLimitPercentage is not a valid decimal number.');
+  }
+
+  const fraction = match[2] ?? '';
+  const exponent = Number(match[3] ?? 0);
+  let numerator = BigInt(`${match[1]}${fraction}`);
+  const scale = fraction.length - exponent;
+  if (scale <= 0) {
+    numerator *= 10n ** BigInt(-scale);
+    return { numerator, denominator: 1n };
+  }
+
+  return { numerator, denominator: 10n ** BigInt(scale) };
+}
+
+function assertValidLightningFeeLimits(params: PayInvoiceParams): void {
+  if (params.feeLimitMsat !== undefined && params.feeLimitPercentage !== undefined) {
+    throw new LniError('InvalidInput', 'Cannot set both feeLimitMsat and feeLimitPercentage.');
+  }
+
+  if (
+    params.feeLimitMsat !== undefined &&
+    (!Number.isSafeInteger(params.feeLimitMsat) || params.feeLimitMsat < 0)
+  ) {
+    throw new LniError('InvalidInput', 'feeLimitMsat must be a non-negative safe integer.');
+  }
+
+  if (
+    params.feeLimitPercentage !== undefined &&
+    (!Number.isFinite(params.feeLimitPercentage) ||
+      params.feeLimitPercentage < 0 ||
+      params.feeLimitPercentage > Number.MAX_SAFE_INTEGER)
+  ) {
+    throw new LniError(
+      'InvalidInput',
+      'feeLimitPercentage must be a non-negative finite safe number.'
+    );
+  }
+}
+
+function assertStrikeLightningFeeLimit(
+  quote: StrikePaymentQuoteResponse,
+  params: PayInvoiceParams
+): void {
+  if (params.feeLimitMsat === undefined && params.feeLimitPercentage === undefined) {
+    return;
+  }
+
+  const feeMsats = strikeQuoteFeeMsats(quote);
+  if (feeMsats === undefined) {
+    const configuredLimit =
+      params.feeLimitMsat !== undefined
+        ? `feeLimitMsat ${params.feeLimitMsat} msats`
+        : `feeLimitPercentage ${params.feeLimitPercentage}%`;
+    throw new LniError(
+      'InvalidInput',
+      `Cannot enforce ${configuredLimit} because the Strike quote fee could not be determined safely.`
+    );
+  }
+
+  if (params.feeLimitMsat !== undefined) {
+    if (feeMsats > BigInt(params.feeLimitMsat)) {
+      const quotedFeeSats = formatMsatsAsSats(feeMsats);
+      const limitSats = formatMsatsAsSats(BigInt(params.feeLimitMsat));
+      throw new FeeError(
+        `Payment not sent: Strike quoted a Lightning fee of ${quotedFeeSats}, which is higher than your configured fee limit of ${limitSats}. Set feeLimitMsat to at least ${feeMsats} (${quotedFeeSats}) to allow this payment.`
+      );
+    }
+    return;
+  }
+
+  const amountMsats = strikeBtcAmountToMsats(quote.amount);
+  if (amountMsats === undefined) {
+    throw new LniError(
+      'InvalidInput',
+      `Cannot enforce feeLimitPercentage ${params.feeLimitPercentage}% because the Strike quote payment amount could not be determined safely.`
+    );
+  }
+
+  const percentage = decimalNumberToFraction(params.feeLimitPercentage!);
+  if (feeMsats * 100n * percentage.denominator > amountMsats * percentage.numerator) {
+    const quotedFeeSats = formatMsatsAsSats(feeMsats);
+    const paymentAmountSats = formatMsatsAsSats(amountMsats);
+    throw new FeeError(
+      `Payment not sent: Strike quoted a Lightning fee of ${quotedFeeSats} for a payment amount of ${paymentAmountSats}, which is higher than your feeLimitPercentage of ${params.feeLimitPercentage}%. Increase feeLimitPercentage or set feeLimitMsat to at least ${feeMsats} (${quotedFeeSats}) to allow this payment.`
+    );
+  }
 }
 
 function defaultOnchainFee(): OnchainFeePreference {
@@ -599,6 +738,8 @@ export class StrikeNode implements LightningNode, OnchainPayments {
   }
 
   async payInvoice(params: PayInvoiceParams): Promise<PayInvoiceResponse> {
+    assertValidLightningFeeLimits(params);
+
     const quote = await this.postJson<StrikePaymentQuoteResponse>(
       '/payment-quotes/lightning',
       {
@@ -615,6 +756,8 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       undefined,
       'pay_invoice'
     );
+
+    assertStrikeLightningFeeLimit(quote, params);
 
     const execution = await this.patchJson<StrikePaymentExecutionResponse>(
       `/payment-quotes/${quote.paymentQuoteId}/execute`,

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -229,19 +229,14 @@ function strikeBtcAmountToMsats(amount: unknown): bigint | undefined {
 }
 
 function strikeQuoteFeeMsats(quote: StrikePaymentQuoteResponse): bigint | undefined {
-  let hasQuotedFee = false;
-  for (const fee of [quote.lightningNetworkFee, quote.totalFee]) {
-    if (fee !== undefined && fee !== null) {
-      hasQuotedFee = true;
-      const feeMsats = strikeBtcAmountToMsats(fee);
-      if (feeMsats !== undefined) {
-        return feeMsats;
-      }
-    }
+  // totalFee is the complete fee charged for the quote. Prefer it over the
+  // Lightning network component so provider fees cannot bypass the guardrail.
+  if (quote.totalFee !== undefined && quote.totalFee !== null) {
+    return strikeBtcAmountToMsats(quote.totalFee);
   }
 
-  if (hasQuotedFee) {
-    return undefined;
+  if (quote.lightningNetworkFee !== undefined && quote.lightningNetworkFee !== null) {
+    return strikeBtcAmountToMsats(quote.lightningNetworkFee);
   }
 
   // Strike-to-Strike/direct quotes can omit fee properties. The quote is provably

--- a/crates/lni/lib.rs
+++ b/crates/lni/lib.rs
@@ -29,6 +29,12 @@ pub enum ApiError {
     LnurlError(String),
     #[error("NwcError: {code}: {message}")]
     Nwc { code: String, message: String },
+    /// A valid quoted or provider fee exceeds a caller-configured fee limit.
+    ///
+    /// The message identifies the quoted fee and the absolute or percentage limit
+    /// that was exceeded. Invalid fee-limit inputs remain `InvalidInput`.
+    #[error("FeeError: {0}")]
+    FeeError(String),
 }
 impl From<serde_json::Error> for ApiError {
     fn from(e: serde_json::Error) -> Self {

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -164,19 +164,14 @@ fn strike_btc_amount_to_msats(amount: Option<&Amount>) -> Option<i64> {
 }
 
 fn strike_quote_fee_msats(quote: &PaymentQuoteResponse) -> Option<i64> {
-    let quoted_fees = [
-        quote.lightning_network_fee.as_ref(),
-        quote.total_fee.as_ref(),
-    ];
-    let has_quoted_fee = quoted_fees.iter().any(Option::is_some);
-    for fee in quoted_fees.into_iter().flatten() {
-        if let Some(fee_msats) = strike_btc_amount_to_msats(Some(fee)) {
-            return Some(fee_msats);
-        }
+    // total_fee is the complete fee charged for the quote. Prefer it over the
+    // Lightning network component so provider fees cannot bypass the guardrail.
+    if quote.total_fee.is_some() {
+        return strike_btc_amount_to_msats(quote.total_fee.as_ref());
     }
 
-    if has_quoted_fee {
-        return None;
+    if quote.lightning_network_fee.is_some() {
+        return strike_btc_amount_to_msats(quote.lightning_network_fee.as_ref());
     }
 
     let amount_msats = strike_btc_amount_to_msats(quote.amount.as_ref());
@@ -1550,6 +1545,19 @@ mod tests {
         assert!(error
             .to_string()
             .contains("Set fee_limit_msat to at least 1001 (1.001 sats)"));
+
+        let total_fee_error = assert_strike_lightning_fee_limit(
+            &lightning_quote(None, Some("0.00000001"), Some("0.00000100"), None),
+            &PayInvoiceParams {
+                fee_limit_msat: Some(2_000),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(&total_fee_error, ApiError::FeeError(_)));
+        assert!(total_fee_error
+            .to_string()
+            .contains("Set fee_limit_msat to at least 100000 (100 sats)"));
     }
 
     #[test]
@@ -1589,7 +1597,7 @@ mod tests {
             fee_limit_msat: Some(1_000),
             ..Default::default()
         };
-        let quote = lightning_quote(None, Some("0.000000010005"), None, None);
+        let quote = lightning_quote(None, Some("0.00000001"), Some("0.000000010005"), None);
 
         let error = assert_strike_lightning_fee_limit(&quote, &params).unwrap_err();
         assert!(error

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -26,6 +26,8 @@ use reqwest::header;
 // Docs
 // https://docs.strike.me/api/
 
+const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
 fn async_client(config: &StrikeConfig) -> reqwest::Client {
     let mut headers = reqwest::header::HeaderMap::new();
     let auth_header = format!("Bearer {}", config.api_key);
@@ -150,6 +152,162 @@ fn amount_to_sats(amount: Option<&Amount>) -> Option<i64> {
         .parse::<f64>()
         .ok()
         .map(|btc| (btc * 100_000_000.0).round() as i64)
+}
+
+fn strike_btc_amount_to_msats(amount: Option<&Amount>) -> Option<i64> {
+    let amount = amount?;
+    if amount.currency != "BTC" {
+        return None;
+    }
+
+    crate::utils::parse_btc_to_msats_exact(&amount.amount)
+}
+
+fn strike_quote_fee_msats(quote: &PaymentQuoteResponse) -> Option<i64> {
+    let quoted_fees = [
+        quote.lightning_network_fee.as_ref(),
+        quote.total_fee.as_ref(),
+    ];
+    let has_quoted_fee = quoted_fees.iter().any(Option::is_some);
+    for fee in quoted_fees.into_iter().flatten() {
+        if let Some(fee_msats) = strike_btc_amount_to_msats(Some(fee)) {
+            return Some(fee_msats);
+        }
+    }
+
+    if has_quoted_fee {
+        return None;
+    }
+
+    let amount_msats = strike_btc_amount_to_msats(quote.amount.as_ref());
+    let total_amount_msats = strike_btc_amount_to_msats(quote.total_amount.as_ref());
+    if amount_msats.is_some() && total_amount_msats == amount_msats {
+        return Some(0);
+    }
+
+    None
+}
+
+fn decimal_to_fraction(value: f64) -> Option<(i128, i128)> {
+    let value = value.to_string().to_ascii_lowercase();
+    let (mantissa, exponent) = match value.split_once('e') {
+        Some((mantissa, exponent)) => (mantissa, exponent.parse::<i32>().ok()?),
+        None => (value.as_str(), 0),
+    };
+    let (whole, fraction) = match mantissa.split_once('.') {
+        Some((whole, fraction)) => (whole, fraction),
+        None => (mantissa, ""),
+    };
+    if whole.is_empty()
+        || !whole.bytes().all(|byte| byte.is_ascii_digit())
+        || !fraction.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let numerator = format!("{}{}", whole, fraction).parse::<i128>().ok()?;
+    let scale = i32::try_from(fraction.len()).ok()?.checked_sub(exponent)?;
+    if scale <= 0 {
+        return Some((
+            numerator.checked_mul(10_i128.checked_pow(scale.unsigned_abs())?)?,
+            1,
+        ));
+    }
+
+    Some((numerator, 10_i128.checked_pow(scale as u32)?))
+}
+
+fn assert_valid_lightning_fee_limits(params: &PayInvoiceParams) -> Result<(), ApiError> {
+    if params.fee_limit_msat.is_some() && params.fee_limit_percentage.is_some() {
+        return Err(ApiError::InvalidInput(
+            "Cannot set both fee_limit_msat and fee_limit_percentage.".to_string(),
+        ));
+    }
+
+    if params
+        .fee_limit_msat
+        .is_some_and(|fee_limit_msat| fee_limit_msat < 0)
+    {
+        return Err(ApiError::InvalidInput(
+            "fee_limit_msat must be a non-negative integer.".to_string(),
+        ));
+    }
+
+    if params.fee_limit_percentage.is_some_and(|percentage| {
+        !percentage.is_finite() || percentage < 0.0 || percentage > MAX_SAFE_INTEGER
+    }) {
+        return Err(ApiError::InvalidInput(
+            "fee_limit_percentage must be a non-negative finite safe number.".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn assert_strike_lightning_fee_limit(
+    quote: &PaymentQuoteResponse,
+    params: &PayInvoiceParams,
+) -> Result<(), ApiError> {
+    if params.fee_limit_msat.is_none() && params.fee_limit_percentage.is_none() {
+        return Ok(());
+    }
+
+    let fee_msats = strike_quote_fee_msats(quote).ok_or_else(|| {
+        let configured_limit = match params.fee_limit_msat {
+            Some(limit) => format!("fee_limit_msat {} msats", limit),
+            None => format!(
+                "fee_limit_percentage {}%",
+                params.fee_limit_percentage.unwrap_or_default()
+            ),
+        };
+        ApiError::InvalidInput(format!(
+            "Cannot enforce {} because the Strike quote fee could not be determined safely.",
+            configured_limit
+        ))
+    })?;
+
+    if let Some(limit) = params.fee_limit_msat {
+        if fee_msats > limit {
+            let quoted_fee_sats = crate::utils::format_msats_as_sats(fee_msats);
+            let limit_sats = crate::utils::format_msats_as_sats(limit);
+            return Err(ApiError::FeeError(format!(
+                "Payment not sent: Strike quoted a Lightning fee of {}, which is higher than your configured fee limit of {}. Set fee_limit_msat to at least {} ({}) to allow this payment.",
+                quoted_fee_sats, limit_sats, fee_msats, quoted_fee_sats
+            )));
+        }
+        return Ok(());
+    }
+
+    let percentage = params.fee_limit_percentage.unwrap_or_default();
+    let amount_msats = strike_btc_amount_to_msats(quote.amount.as_ref()).ok_or_else(|| {
+        ApiError::InvalidInput(format!(
+            "Cannot enforce fee_limit_percentage {}% because the Strike quote payment amount could not be determined safely.",
+            percentage
+        ))
+    })?;
+    let (percentage_numerator, percentage_denominator) = decimal_to_fraction(percentage)
+        .ok_or_else(|| {
+            ApiError::InvalidInput(
+                "fee_limit_percentage must be a non-negative finite safe number.".to_string(),
+            )
+        })?;
+    let quoted_fee_ratio = i128::from(fee_msats)
+        .checked_mul(100)
+        .and_then(|value| value.checked_mul(percentage_denominator));
+    let configured_fee_ratio = i128::from(amount_msats).checked_mul(percentage_numerator);
+    if quoted_fee_ratio.is_none()
+        || configured_fee_ratio.is_none()
+        || quoted_fee_ratio > configured_fee_ratio
+    {
+        let quoted_fee_sats = crate::utils::format_msats_as_sats(fee_msats);
+        let payment_amount_sats = crate::utils::format_msats_as_sats(amount_msats);
+        return Err(ApiError::FeeError(format!(
+            "Payment not sent: Strike quoted a Lightning fee of {} for a payment amount of {}, which is higher than your fee_limit_percentage of {}%. Increase fee_limit_percentage or set fee_limit_msat to at least {} ({}) to allow this payment.",
+            quoted_fee_sats, payment_amount_sats, percentage, fee_msats, quoted_fee_sats
+        )));
+    }
+
+    Ok(())
 }
 
 fn is_retryable_payment_read_status(status: reqwest::StatusCode) -> bool {
@@ -312,10 +470,7 @@ pub async fn get_info(config: StrikeConfig) -> Result<NodeInfo, ApiError> {
     let send_balance_msat = balances
         .iter()
         .find(|balance| balance.currency == "BTC")
-        .map(|balance| {
-            let btc_amount = balance.current.parse::<f64>().unwrap_or(0.0);
-            (btc_amount * 100_000_000_000.0) as i64
-        })
+        .and_then(|balance| crate::utils::parse_btc_to_msats_exact(&balance.current))
         .unwrap_or(0);
 
     Ok(NodeInfo {
@@ -348,9 +503,8 @@ pub async fn create_invoice(
 
             let amount = invoice_params.amount_msats.map(|amt| {
                 // Convert msats to BTC (Strike expects BTC amounts)
-                let btc_amount = amt as f64 / 100_000_000_000.0;
                 Amount {
-                    amount: format!("{:.8}", btc_amount),
+                    amount: crate::utils::msats_to_btc(amt),
                     currency: "BTC".to_string(),
                     fee_policy: None,
                 }
@@ -431,6 +585,8 @@ pub async fn pay_invoice(
     config: StrikeConfig,
     invoice_params: PayInvoiceParams,
 ) -> Result<PayInvoiceResponse, ApiError> {
+    assert_valid_lightning_fee_limits(&invoice_params)?;
+
     let client = async_client(&config);
 
     // Create payment quote first
@@ -441,7 +597,7 @@ pub async fn pay_invoice(
         amount: invoice_params
             .amount_msats
             .map(|amt| super::types::PaymentQuoteAmount {
-                amount: format!("{:.8}", amt as f64 / 100_000_000_000.0),
+                amount: crate::utils::msats_to_btc(amt),
                 currency: "BTC".to_string(),
             }),
     };
@@ -466,6 +622,7 @@ pub async fn pay_invoice(
 
     let quote_text = quote_response.text().await.unwrap();
     let quote_resp: PaymentQuoteResponse = serde_json::from_str(&quote_text)?;
+    assert_strike_lightning_fee_limit(&quote_resp, &invoice_params)?;
 
     // Execute the payment quote
     let execute_url = format!(
@@ -544,9 +701,7 @@ pub async fn pay_invoice(
                 .as_ref()
                 .and_then(|payment| payment.lightning_network_fee.as_ref())
         })
-        .filter(|fee| fee.currency == "BTC")
-        .and_then(|fee| fee.amount.parse::<f64>().ok())
-        .map(|fee| (fee * 100_000_000_000.0) as i64)
+        .and_then(|fee| strike_btc_amount_to_msats(Some(fee)))
         .unwrap_or(0);
 
     // Extract payment hash from the original BOLT11 invoice
@@ -985,13 +1140,7 @@ pub async fn lookup_invoice(
         reason: "No lightning information in receive".to_string(),
     })?;
 
-    // Convert amount to millisatoshis
-    let amount_msats = if receive.amount_received.currency == "BTC" {
-        let btc_amount = receive.amount_received.amount.parse::<f64>().unwrap_or(0.0);
-        (btc_amount * 100_000_000_000.0) as i64
-    } else {
-        0
-    };
+    let amount_msats = strike_btc_amount_to_msats(Some(&receive.amount_received)).unwrap_or(0);
 
     Ok(Transaction {
         type_: "incoming".to_string(),
@@ -1059,13 +1208,8 @@ pub async fn list_transactions(
 
         for receive in receives_resp.items {
             if let Some(lightning_info) = receive.lightning {
-                // Convert amount to millisatoshis
-                let amount_msats = if receive.amount_received.currency == "BTC" {
-                    let btc_amount = receive.amount_received.amount.parse::<f64>().unwrap_or(0.0);
-                    (btc_amount * 100_000_000_000.0) as i64
-                } else {
-                    0
-                };
+                let amount_msats =
+                    strike_btc_amount_to_msats(Some(&receive.amount_received)).unwrap_or(0);
 
                 transactions.push(Transaction {
                     type_: "incoming".to_string(),
@@ -1127,27 +1271,13 @@ pub async fn list_transactions(
         let payments_resp: PaymentsResponse = serde_json::from_str(&payments_text)?;
 
         for payment in payments_resp.data {
-            let amount_msats = if payment.amount.currency == "BTC" {
-                let btc_amount = payment.amount.amount.parse::<f64>().unwrap_or(0.0);
-                (btc_amount * 100_000_000_000.0) as i64
-            } else {
-                0
-            };
-
-            let fee_msats = if let Some(lightning) = &payment.lightning {
-                if let Some(network_fee) = &lightning.network_fee {
-                    let fee_amount = network_fee.amount.parse::<f64>().unwrap_or(0.0);
-                    if network_fee.currency == "BTC" {
-                        (fee_amount * 100_000_000_000.0) as i64
-                    } else {
-                        0
-                    }
-                } else {
-                    0
-                }
-            } else {
-                0
-            };
+            let amount_msats = strike_btc_amount_to_msats(Some(&payment.amount)).unwrap_or(0);
+            let fee_msats = payment
+                .lightning
+                .as_ref()
+                .and_then(|lightning| lightning.network_fee.as_ref())
+                .and_then(|fee| strike_btc_amount_to_msats(Some(fee)))
+                .unwrap_or(0);
 
             transactions.push(Transaction {
                 type_: "outgoing".to_string(),
@@ -1278,6 +1408,31 @@ pub async fn on_invoice_events(
 mod tests {
     use super::*;
 
+    fn btc_amount(amount: &str) -> Amount {
+        Amount {
+            amount: amount.to_string(),
+            currency: "BTC".to_string(),
+            fee_policy: None,
+        }
+    }
+
+    fn lightning_quote(
+        amount: Option<&str>,
+        lightning_fee: Option<&str>,
+        total_fee: Option<&str>,
+        total_amount: Option<&str>,
+    ) -> PaymentQuoteResponse {
+        PaymentQuoteResponse {
+            lightning_network_fee: lightning_fee.map(btc_amount),
+            payment_quote_id: "quote-1".to_string(),
+            valid_until: "2030-01-01T00:00:00Z".to_string(),
+            conversion_rate: None,
+            amount: amount.map(btc_amount),
+            total_fee: total_fee.map(btc_amount),
+            total_amount: total_amount.map(btc_amount),
+        }
+    }
+
     fn test_onchain_transaction(fee_sats: Option<i64>) -> OnchainTransaction {
         OnchainTransaction {
             id: Some("quote-1".to_string()),
@@ -1367,6 +1522,90 @@ mod tests {
         assert!(!is_retryable_payment_read_status(
             reqwest::StatusCode::UNAUTHORIZED
         ));
+    }
+
+    #[test]
+    fn enforces_absolute_strike_lightning_fee_limit() {
+        let params = PayInvoiceParams {
+            fee_limit_msat: Some(1_000),
+            ..Default::default()
+        };
+
+        assert!(assert_strike_lightning_fee_limit(
+            &lightning_quote(None, Some("0.00000000999"), None, None),
+            &params,
+        )
+        .is_ok());
+        assert!(assert_strike_lightning_fee_limit(
+            &lightning_quote(None, None, Some("0.00000001000"), None),
+            &params,
+        )
+        .is_ok());
+        let error = assert_strike_lightning_fee_limit(
+            &lightning_quote(None, Some("0.00000001001"), None, None),
+            &params,
+        )
+        .unwrap_err();
+        assert!(matches!(&error, ApiError::FeeError(_)));
+        assert!(error
+            .to_string()
+            .contains("Set fee_limit_msat to at least 1001 (1.001 sats)"));
+    }
+
+    #[test]
+    fn enforces_percentage_strike_lightning_fee_limit() {
+        let quote = lightning_quote(Some("0.00001000"), Some("0.00000010"), None, None);
+        let equal_limit = PayInvoiceParams {
+            fee_limit_percentage: Some(1.0),
+            ..Default::default()
+        };
+        let below_limit = PayInvoiceParams {
+            fee_limit_percentage: Some(0.99),
+            ..Default::default()
+        };
+
+        assert!(assert_strike_lightning_fee_limit(&quote, &equal_limit).is_ok());
+        let error = assert_strike_lightning_fee_limit(&quote, &below_limit).unwrap_err();
+        assert!(matches!(&error, ApiError::FeeError(_)));
+        assert!(error
+            .to_string()
+            .contains("higher than your fee_limit_percentage of 0.99%"));
+    }
+
+    #[test]
+    fn allows_provably_fee_free_direct_strike_quote() {
+        let params = PayInvoiceParams {
+            fee_limit_msat: Some(0),
+            ..Default::default()
+        };
+        let quote = lightning_quote(Some("0.00001000"), None, None, Some("0.00001000"));
+
+        assert!(assert_strike_lightning_fee_limit(&quote, &params).is_ok());
+    }
+
+    #[test]
+    fn strike_lightning_fee_limit_fails_closed_for_imprecise_fee() {
+        let params = PayInvoiceParams {
+            fee_limit_msat: Some(1_000),
+            ..Default::default()
+        };
+        let quote = lightning_quote(None, Some("0.000000010005"), None, None);
+
+        let error = assert_strike_lightning_fee_limit(&quote, &params).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("quote fee could not be determined safely"));
+    }
+
+    #[test]
+    fn rejects_conflicting_strike_lightning_fee_limits() {
+        let params = PayInvoiceParams {
+            fee_limit_msat: Some(1_000),
+            fee_limit_percentage: Some(1.0),
+            ..Default::default()
+        };
+
+        assert!(assert_valid_lightning_fee_limits(&params).is_err());
     }
 
     #[test]

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -281,6 +281,7 @@ mod tests {
         match NODE
             .pay_invoice(PayInvoiceParams {
                 invoice: TEST_PAYMENT_REQUEST.to_string(),
+                fee_limit_percentage: Some(1.0), // 1%
                 ..Default::default()
             })
             .await
@@ -301,6 +302,151 @@ mod tests {
                 // Don't panic as this requires valid API key and invoice
             }
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "requests a real Strike quote but never executes it"]
+    async fn test_inspect_pay_invoice_quote_fees() {
+        let response = reqwest::Client::new()
+            .post(format!(
+                "{}/payment-quotes/lightning",
+                BASE_URL.trim_end_matches('/')
+            ))
+            .bearer_auth(API_KEY.as_str())
+            .json(&crate::strike::types::PaymentQuoteRequest {
+                ln_invoice: TEST_PAYMENT_REQUEST.to_string(),
+                source_currency: "BTC".to_string(),
+                amount: None,
+            })
+            .send()
+            .await
+            .expect("Strike quote request should succeed");
+        let status = response.status();
+        let quote_body = response
+            .text()
+            .await
+            .expect("Strike quote response should be readable");
+        assert!(
+            status.is_success(),
+            "Strike quote request failed with HTTP status {status}"
+        );
+
+        let quote: crate::strike::types::PaymentQuoteResponse =
+            serde_json::from_str(&quote_body).expect("Strike quote should be valid JSON");
+        let lightning_network_fee_msats = quote
+            .lightning_network_fee
+            .as_ref()
+            .and_then(|fee| crate::utils::parse_btc_to_msats_exact(&fee.amount));
+        let total_fee_msats = quote
+            .total_fee
+            .as_ref()
+            .and_then(|fee| crate::utils::parse_btc_to_msats_exact(&fee.amount));
+
+        dbg!(&quote.lightning_network_fee);
+        dbg!(lightning_network_fee_msats);
+        dbg!(&quote.total_fee);
+        dbg!(total_fee_msats);
+        dbg!(&quote.amount);
+        dbg!(&quote.total_amount);
+    }
+
+    #[tokio::test]
+    async fn test_pay_invoice_rejects_fee_above_limit_without_executing_quote() {
+        use std::time::Duration;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test HTTP server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test HTTP server should have an address");
+
+        let server = tokio::spawn(async move {
+            let (mut quote_socket, _) = listener
+                .accept()
+                .await
+                .expect("quote request should connect");
+            let mut request = vec![0_u8; 8_192];
+            let request_len = quote_socket
+                .read(&mut request)
+                .await
+                .expect("quote request should be readable");
+            let request = String::from_utf8_lossy(&request[..request_len]);
+            assert!(
+                request.starts_with("POST /payment-quotes/lightning "),
+                "expected Lightning quote request, got: {request}"
+            );
+
+            let quote = r#"{
+                "paymentQuoteId": "quote-1",
+                "validUntil": "2030-01-01T00:00:00Z",
+                "amount": { "amount": "0.00001000", "currency": "BTC" },
+                "lightningNetworkFee": { "amount": "0.00000001", "currency": "BTC" },
+                "totalFee": { "amount": "0.00000001", "currency": "BTC" },
+                "totalAmount": { "amount": "0.00001001", "currency": "BTC" }
+            }"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                quote.len(),
+                quote
+            );
+            quote_socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("quote response should be writable");
+            quote_socket
+                .shutdown()
+                .await
+                .expect("quote connection should close");
+
+            match tokio::time::timeout(Duration::from_millis(250), listener.accept()).await {
+                Ok(Ok((mut execute_socket, _))) => {
+                    let response = "HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                    execute_socket
+                        .write_all(response.as_bytes())
+                        .await
+                        .expect("execute failure response should be writable");
+                    true
+                }
+                Ok(Err(error)) => panic!("test HTTP server failed while awaiting execute: {error}"),
+                Err(_) => false,
+            }
+        });
+
+        let node = StrikeNode::new(StrikeConfig {
+            base_url: Some(format!("http://{address}")),
+            api_key: "test-token".to_string(),
+            http_timeout: Some(5),
+            socks5_proxy: Some(String::new()),
+            accept_invalid_certs: Some(false),
+        });
+        let result = node
+            .pay_invoice(PayInvoiceParams {
+                invoice: "lnbc1testinvoice".to_string(),
+                fee_limit_msat: Some(0),
+                ..Default::default()
+            })
+            .await;
+        let execute_attempted = server.await.expect("test HTTP server should finish");
+
+        let error = result.expect_err("positive quoted fee should exceed the zero-msat limit");
+        dbg!(&error);
+        assert!(
+            matches!(&error, ApiError::FeeError(_)),
+            "expected FeeError rejection, got: {error:?}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("Set fee_limit_msat to at least 1000 (1 sat)"),
+            "unexpected fee-limit error: {error}"
+        );
+        assert!(
+            !execute_attempted,
+            "Strike must not call the quote execute endpoint after a fee-limit rejection"
+        );
     }
 
     #[tokio::test]

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -384,8 +384,8 @@ mod tests {
                 "validUntil": "2030-01-01T00:00:00Z",
                 "amount": { "amount": "0.00001000", "currency": "BTC" },
                 "lightningNetworkFee": { "amount": "0.00000001", "currency": "BTC" },
-                "totalFee": { "amount": "0.00000001", "currency": "BTC" },
-                "totalAmount": { "amount": "0.00001001", "currency": "BTC" }
+                "totalFee": { "amount": "0.00000100", "currency": "BTC" },
+                "totalAmount": { "amount": "0.00001100", "currency": "BTC" }
             }"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -425,13 +425,13 @@ mod tests {
         let result = node
             .pay_invoice(PayInvoiceParams {
                 invoice: "lnbc1testinvoice".to_string(),
-                fee_limit_msat: Some(0),
+                fee_limit_msat: Some(2_000),
                 ..Default::default()
             })
             .await;
         let execute_attempted = server.await.expect("test HTTP server should finish");
 
-        let error = result.expect_err("positive quoted fee should exceed the zero-msat limit");
+        let error = result.expect_err("total quoted fee should exceed the two-sat limit");
         dbg!(&error);
         assert!(
             matches!(&error, ApiError::FeeError(_)),
@@ -440,7 +440,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("Set fee_limit_msat to at least 1000 (1 sat)"),
+                .contains("Set fee_limit_msat to at least 100000 (100 sats)"),
             "unexpected fee-limit error: {error}"
         );
         assert!(

--- a/crates/lni/strike/types.rs
+++ b/crates/lni/strike/types.rs
@@ -177,18 +177,18 @@ pub struct PaymentQuoteAmount {
 #[derive(Debug, Deserialize)]
 pub struct PaymentQuoteResponse {
     #[serde(rename = "lightningNetworkFee")]
-    pub lightning_network_fee: Amount,
+    pub lightning_network_fee: Option<Amount>,
     #[serde(rename = "paymentQuoteId")]
     pub payment_quote_id: String,
     #[serde(rename = "validUntil")]
     pub valid_until: String,
     #[serde(rename = "conversionRate")]
     pub conversion_rate: Option<ConversionRate>,
-    pub amount: Amount,
+    pub amount: Option<Amount>,
     #[serde(rename = "totalFee")]
-    pub total_fee: Amount,
+    pub total_fee: Option<Amount>,
     #[serde(rename = "totalAmount")]
-    pub total_amount: Amount,
+    pub total_amount: Option<Amount>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -512,6 +512,26 @@ pub struct ReceiveRequestsResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deserializes_fee_free_quote_without_fee_fields() {
+        let quote: PaymentQuoteResponse = serde_json::from_str(
+            r#"{
+                "paymentQuoteId": "quote-1",
+                "validUntil": "2030-01-01T00:00:00Z",
+                "amount": { "amount": "0.00001000", "currency": "BTC" },
+                "totalAmount": { "amount": "0.00001000", "currency": "BTC" }
+            }"#,
+        )
+        .expect("fee-free quote should deserialize");
+
+        assert!(quote.lightning_network_fee.is_none());
+        assert!(quote.total_fee.is_none());
+        assert_eq!(
+            quote.amount.as_ref().map(|amount| amount.amount.as_str()),
+            Some("0.00001000")
+        );
+    }
 
     #[test]
     fn deserializes_payment_detail_lightning_proof() {

--- a/crates/lni/utils.rs
+++ b/crates/lni/utils.rs
@@ -6,6 +6,64 @@ use serde_json::{json, Map, Value};
 use std::error::Error;
 use std::str::FromStr;
 
+const MSATS_PER_BTC: i128 = 100_000_000_000;
+
+pub fn parse_btc_to_msats_exact(amount: &str) -> Option<i64> {
+    let (whole, fraction) = match amount.split_once('.') {
+        Some((whole, fraction)) => (whole, fraction),
+        None => (amount, ""),
+    };
+    if whole.is_empty()
+        || !whole.bytes().all(|byte| byte.is_ascii_digit())
+        || (!fraction.is_empty() && !fraction.bytes().all(|byte| byte.is_ascii_digit()))
+        || amount.ends_with('.')
+    {
+        return None;
+    }
+
+    if fraction.len() > 11 && fraction.as_bytes()[11..].iter().any(|byte| *byte != b'0') {
+        return None;
+    }
+
+    let whole_msats = whole.parse::<i128>().ok()?.checked_mul(MSATS_PER_BTC)?;
+    let significant_fraction = &fraction[..fraction.len().min(11)];
+    let fractional_msats = if significant_fraction.is_empty() {
+        0
+    } else {
+        significant_fraction
+            .parse::<i128>()
+            .ok()?
+            .checked_mul(10_i128.checked_pow((11 - significant_fraction.len()) as u32)?)?
+    };
+
+    i64::try_from(whole_msats.checked_add(fractional_msats)?).ok()
+}
+
+pub fn msats_to_btc(amount_msats: i64) -> String {
+    format!("{:.8}", amount_msats as f64 / MSATS_PER_BTC as f64)
+}
+
+pub fn format_msats_as_sats(amount_msats: i64) -> String {
+    let is_negative = amount_msats < 0;
+    let absolute_msats = i128::from(amount_msats).abs();
+    let whole_sats = absolute_msats / 1_000;
+    let fractional_msats = absolute_msats % 1_000;
+    let sign = if is_negative { "-" } else { "" };
+    let amount = if fractional_msats == 0 {
+        format!("{sign}{whole_sats}")
+    } else {
+        let fraction = format!("{fractional_msats:03}");
+        format!("{sign}{whole_sats}.{}", fraction.trim_end_matches('0'))
+    };
+    let unit = if absolute_msats == 1_000 {
+        "sat"
+    } else {
+        "sats"
+    };
+
+    format!("{amount} {unit}")
+}
+
 pub fn calculate_fee_msats(
     bolt11: &str,
     fee_percentage: f64,
@@ -283,6 +341,26 @@ mod decode_tests {
         "lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg";
     const BOLT12_OFFER_WITH_CURRENCY_AMOUNT: &str = "lno1qcp4256ypqpzwyq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj";
     const BOLT12_OFFER_WITH_PATH: &str = "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zyg3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs";
+
+    #[test]
+    fn parses_btc_amounts_to_msats_exactly() {
+        assert_eq!(super::parse_btc_to_msats_exact("0.00000000999"), Some(999));
+        assert_eq!(
+            super::parse_btc_to_msats_exact("0.00000001001"),
+            Some(1_001)
+        );
+        assert_eq!(
+            super::parse_btc_to_msats_exact("1.00000000000"),
+            Some(100_000_000_000)
+        );
+        assert_eq!(super::parse_btc_to_msats_exact("0.000000000001"), None);
+        assert_eq!(super::parse_btc_to_msats_exact("not-an-amount"), None);
+        assert_eq!(super::msats_to_btc(1_000), "0.00000001");
+        assert_eq!(super::format_msats_as_sats(0), "0 sats");
+        assert_eq!(super::format_msats_as_sats(1_000), "1 sat");
+        assert_eq!(super::format_msats_as_sats(1_001), "1.001 sats");
+        assert_eq!(super::format_msats_as_sats(4_000), "4 sats");
+    }
 
     #[test]
     fn decodes_bolt11_as_json() {

--- a/docs/error-normalization.md
+++ b/docs/error-normalization.md
@@ -36,6 +36,28 @@ Sources checked on 2026-07-07:
 
 Local input validation should remain `LniError('InvalidInput', ...)` unless the provider accepted the request and returned a categorized business error.
 
+## Local Fee Errors
+
+Rust exposes `ApiError::FeeError(String)` and TypeScript exposes `FeeError` (with
+`LniError.code === 'FeeError'`) for a valid quoted or provider fee that exceeds a
+caller-configured fee limit. This is a local LNI guardrail error, not a standard NWC
+error code and not a provider payment failure.
+
+Current Strike Lightning behavior:
+
+| Condition | Error |
+| --- | --- |
+| Quoted fee exceeds the absolute limit | Rust `ApiError::FeeError` / TypeScript `FeeError`, with quoted and limit amounts displayed in sats plus the exact msat value needed to allow the payment |
+| Quoted fee exceeds the percentage limit | Rust `ApiError::FeeError` / TypeScript `FeeError`, with quoted fee and payment amount displayed in sats, the percentage limit, and guidance to increase the percentage or use a sufficient absolute limit |
+| Quoted fee equals either limit | Payment is allowed |
+| Both fee-limit forms are supplied | `InvalidInput` |
+| A fee limit is negative, non-finite, or unsafe | `InvalidInput` |
+| A limit is supplied but the quote fee cannot be determined safely | `InvalidInput` |
+
+Strike creates the quote before enforcing the limit because its API does not accept a
+maximum fee parameter. LNI checks the returned quote before calling `/execute`; a
+`FeeError` therefore means the quote was not executed.
+
 ## Fallback Rules
 
 Apply exact provider-code mappings first. If no exact mapping exists, use these fallbacks:

--- a/docs/error-normalization.md
+++ b/docs/error-normalization.md
@@ -56,7 +56,9 @@ Current Strike Lightning behavior:
 
 Strike creates the quote before enforcing the limit because its API does not accept a
 maximum fee parameter. LNI checks the returned quote before calling `/execute`; a
-`FeeError` therefore means the quote was not executed.
+`FeeError` therefore means the quote was not executed. When Strike supplies both its
+total fee and Lightning network fee fields, LNI enforces the total fee; it uses the
+network fee only when the total fee is absent.
 
 ## Fallback Rules
 

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,59 @@ const listTxnParams = {
 const txns = await node.listTransactions(listTxnParams);
 ```
 
+`StrikeNode.payInvoice` supports `feeLimitMsat` and `feeLimitPercentage`. Strike does not
+accept a maximum fee in the payment request, so LNI enforces the configured limit by
+validating the returned Lightning quote before executing it. Percentage limits use the
+payment amount before fees, and no fee limit is applied when neither field is provided.
+
+#### Fee Errors
+
+Rust adapters can return `ApiError::FeeError(message)`, and TypeScript adapters can throw
+`FeeError`, when a valid quoted fee exceeds a caller-configured fee limit. The message
+includes exact sat amounts and the configured absolute or percentage limit. For Strike
+Lightning payments, this check happens after quote creation and before `/execute`, so an
+over-limit quote is not paid.
+
+```rust
+match node.pay_invoice(PayInvoiceParams {
+    invoice,
+    fee_limit_msat: Some(1_000),
+    ..Default::default()
+}).await {
+    Err(ApiError::FeeError(message)) => {
+        // Example:
+        // "Payment not sent: Strike quoted a Lightning fee of 4 sats, which is
+        // higher than your configured fee limit of 1 sat. Set fee_limit_msat to
+        // at least 4000 (4 sats) to allow this payment."
+        eprintln!("{message}");
+    }
+    Err(error) => return Err(error),
+    Ok(payment) => println!("payment hash: {}", payment.payment_hash),
+}
+```
+
+`FeeError` means the fee was determined successfully but exceeded the configured limit.
+Invalid limits—such as negative values or supplying both limit forms—and quotes whose
+fee cannot be determined safely continue to return `ApiError::InvalidInput`.
+
+```typescript
+import { FeeError } from '@sunnyln/lni';
+
+try {
+    await node.payInvoice({
+        invoice,
+        feeLimitMsat: 1_000,
+    });
+} catch (error) {
+    if (error instanceof FeeError) {
+        console.error(error.message);
+    }
+}
+```
+
+In TypeScript, invalid fee limits and quotes whose fee cannot be determined safely
+continue to throw `LniError` with `code === 'InvalidInput'`.
+
 #### Decode
 
 Decode helpers are pure local functions. They do not require node config.

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,8 @@ const txns = await node.listTransactions(listTxnParams);
 accept a maximum fee in the payment request, so LNI enforces the configured limit by
 validating the returned Lightning quote before executing it. Percentage limits use the
 payment amount before fees, and no fee limit is applied when neither field is provided.
+When Strike returns both its total fee and Lightning network fee, LNI enforces the total
+fee because it represents the complete quoted charge.
 
 #### Fee Errors
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable absolute and percentage fee limits for Strike Lightning invoice payments.
  - Added clear `FeeError` reporting when quoted fees exceed configured limits.
  - Added precise BTC, millisatoshi, and satoshi conversion and formatting.

- **Bug Fixes**
  - Improved handling of fee-free, malformed, or imprecise payment quotes.
  - Prevented payment execution when fee limits cannot be safely verified.

- **Documentation**
  - Documented fee-limit configuration, validation rules, and error handling in Rust and TypeScript guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->