### PR TITLE
fix(ts): validate provider payment preimages

### DIFF
--- a/bindings/typescript/src/__tests__/nwc.test.ts
+++ b/bindings/typescript/src/__tests__/nwc.test.ts
@@ -269,7 +269,7 @@ describe('NwcNode.payInvoice', () => {
     });
 
     await expect(makeNode().payInvoice({ invoice: BOLT11_INVOICE })).rejects.toThrow(
-      'Web Crypto API or a registered SHA-256 digest fallback is required to hash NWC preimages.'
+      'Web Crypto API or a registered SHA-256 digest fallback is required to hash payment preimages.'
     );
   });
 });

--- a/bindings/typescript/src/__tests__/payment-proof.test.ts
+++ b/bindings/typescript/src/__tests__/payment-proof.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { validPaymentPreimageForHash } from '../internal/payment-proof.js';
+
+const ZERO_PREIMAGE = '0000000000000000000000000000000000000000000000000000000000000000';
+const ZERO_PREIMAGE_PAYMENT_HASH =
+  '66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925';
+
+describe('payment proof validation', () => {
+  it('accepts a 32-byte hex preimage only when it hashes to the invoice payment hash', async () => {
+    await expect(validPaymentPreimageForHash(ZERO_PREIMAGE, ZERO_PREIMAGE_PAYMENT_HASH)).resolves.toBe(
+      ZERO_PREIMAGE
+    );
+  });
+
+  it('rejects forged, malformed, or wrong-length preimages', async () => {
+    await expect(validPaymentPreimageForHash('ff'.repeat(32), ZERO_PREIMAGE_PAYMENT_HASH)).resolves.toBe(
+      ''
+    );
+    await expect(validPaymentPreimageForHash('not-hex', ZERO_PREIMAGE_PAYMENT_HASH)).resolves.toBe('');
+    await expect(validPaymentPreimageForHash('00', ZERO_PREIMAGE_PAYMENT_HASH)).resolves.toBe('');
+  });
+});

--- a/bindings/typescript/src/internal/payment-proof.ts
+++ b/bindings/typescript/src/internal/payment-proof.ts
@@ -1,0 +1,27 @@
+import { hexToBytes } from './encoding.js';
+import { sha256Hex } from './sha256.js';
+
+const PREIMAGE_BYTE_LENGTH = 32;
+
+export async function validPaymentPreimageForHash(
+  preimage: string | undefined,
+  paymentHash: string
+): Promise<string> {
+  if (!preimage || !paymentHash) {
+    return '';
+  }
+
+  let preimageBytes: Uint8Array;
+  try {
+    preimageBytes = hexToBytes(preimage);
+  } catch {
+    return '';
+  }
+
+  if (preimageBytes.length !== PREIMAGE_BYTE_LENGTH) {
+    return '';
+  }
+
+  const derivedPaymentHash = await sha256Hex(preimageBytes);
+  return derivedPaymentHash === paymentHash.trim().toLowerCase() ? preimage : '';
+}

--- a/bindings/typescript/src/internal/sha256.ts
+++ b/bindings/typescript/src/internal/sha256.ts
@@ -22,6 +22,6 @@ export async function sha256Hex(bytes: Uint8Array): Promise<string> {
 
   throw new LniError(
     'Api',
-    'Web Crypto API or a registered SHA-256 digest fallback is required to hash NWC preimages.'
+    'Web Crypto API or a registered SHA-256 digest fallback is required to hash payment preimages.'
   );
 }

--- a/bindings/typescript/src/nodes/blink.ts
+++ b/bindings/typescript/src/nodes/blink.ts
@@ -7,6 +7,7 @@ import {
 } from '../internal/error-normalization.js';
 import { requestJson, resolveFetch, toTimeoutMs } from '../internal/http.js';
 import { getBlinkTokenPermissions } from '../internal/permissions.js';
+import { validPaymentPreimageForHash } from '../internal/payment-proof.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import {
   emptyNodeInfo,
@@ -708,14 +709,19 @@ export class BlinkNode implements LightningNode, OnchainPayments {
 
     // The proof of payment: SettlementViaLn and SettlementViaIntraLedger
     // (payer and payee both on Blink) each expose the settled pre-image.
-    const preimage = payment.lnInvoicePaymentSend.transaction?.settlementVia?.preImage ?? '';
+    // Treat it as proof only if it hashes to the invoice payment hash.
     let paymentHash = '';
-    if (preimage) {
-      try {
-        paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
-      } catch {
-        paymentHash = '';
-      }
+    try {
+      paymentHash = decodeBolt11(params.invoice).payment_hash ?? '';
+    } catch {
+      paymentHash = '';
+    }
+    const preimage = await validPaymentPreimageForHash(
+      payment.lnInvoicePaymentSend.transaction?.settlementVia?.preImage,
+      paymentHash
+    );
+    if (!preimage) {
+      paymentHash = '';
     }
 
     return {

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -8,6 +8,7 @@ import {
 } from '../internal/error-normalization.js';
 import { buildUrl, requestJson, requestText, resolveFetch, toTimeoutMs } from '../internal/http.js';
 import { getStrikeOauthPermissions } from '../internal/permissions.js';
+import { validPaymentPreimageForHash } from '../internal/payment-proof.js';
 import { pollInvoiceEvents } from '../internal/polling.js';
 import {
   btcToMsats,
@@ -621,9 +622,12 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       ? btcToMsats(payment.lightning.networkFee.amount)
       : 0;
 
+    const paymentHash = paymentHashFromInvoice(params.invoice);
+    const preimage = await validPaymentPreimageForHash(payment?.lightning?.preImage, paymentHash);
+
     return {
-      paymentHash: payment?.lightning?.paymentHash ?? paymentHashFromInvoice(params.invoice),
-      preimage: payment?.lightning?.preImage ?? '',
+      paymentHash,
+      preimage,
       feeMsats,
     };
   }


### PR DESCRIPTION
### Motivation
- Recent changes began returning provider-supplied lightning preimages as proof-of-payment without verifying their cryptographic relation to the paid invoice, which allows forged preimages/payment hashes to be accepted as valid proof. 
- The TypeScript bindings must mirror the Rust semantics and ensure `sha256(preimage) == invoice payment hash` before treating a preimage as proof so consumers cannot be tricked by malicious provider responses.

### Description
- Add shared validator `validPaymentPreimageForHash` that accepts only 32-byte hex preimages whose `sha256` matches the invoice payment hash (`bindings/typescript/src/internal/payment-proof.ts`).
- Use invoice-derived payment hash and validate provider preimages in Blink `payInvoice`, omitting proof fields when validation fails (`bindings/typescript/src/nodes/blink.ts`).
- Stop trusting provider-supplied payment hashes for Strike proof construction and validate provider preimages against the invoice-derived hash (`bindings/typescript/src/nodes/strike.ts`).
- Generalize SHA-256 fallback error wording to reference payment preimages instead of only NWC (`bindings/typescript/src/internal/sha256.ts`).
- Add unit tests for the new validator covering valid, forged, malformed, and wrong-length preimages (`bindings/typescript/src/__tests__/payment-proof.test.ts`) and update an existing NWC test expectation to match the new error text (`bindings/typescript/src/__tests__/nwc.test.ts`).

### Testing
- Ran `npm run typecheck` in `bindings/typescript` and it passed (`tsc --noEmit`).
- Ran unit tests `npm test -- --run src/__tests__/nwc.test.ts src/__tests__/payment-proof.test.ts` and all tests passed.
- Performed `npm run pack:dry-run` in `bindings/typescript` to validate packaging and it succeeded.
- Added a focused unit test `src/__tests__/payment-proof.test.ts` which passed and validates acceptance/rejection cases for preimages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a597176a5f88328aff10b6b76fd80ac)