### PR TITLE
Support Strike Onchain listTransactions

### DIFF
--- a/bindings/lni_nodejs/index.d.ts
+++ b/bindings/lni_nodejs/index.d.ts
@@ -132,6 +132,18 @@ export interface NodeInfo {
   pendingOpenSendBalance: number
   pendingOpenReceiveBalance: number
 }
+export const enum SettlementType {
+  Lightning = 'Lightning',
+  Onchain = 'Onchain',
+  Intraledger = 'Intraledger',
+  Unknown = 'Unknown'
+}
+export const enum SettlementState {
+  Pending = 'Pending',
+  Completed = 'Completed',
+  Failed = 'Failed',
+  Unknown = 'Unknown'
+}
 export interface Transaction {
   type: string
   invoice: string
@@ -146,6 +158,9 @@ export interface Transaction {
   settledAt: number
   payerNote?: string
   externalId?: string
+  settlementType?: SettlementType
+  settlementState?: SettlementState
+  txid?: string
 }
 export interface NodeConnectionInfo {
   pubkey: string

--- a/bindings/lni_nodejs/src/strike.rs
+++ b/bindings/lni_nodejs/src/strike.rs
@@ -131,14 +131,9 @@ impl StrikeNode {
     &self,
     params: crate::ListTransactionsParams,
   ) -> napi::Result<Vec<lni::Transaction>> {
-    let txns = lni::strike::api::list_transactions(
-      self.inner.clone(),
-      params.from,
-      params.limit,
-      params.search,
-    )
-    .await
-    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    let txns = lni::strike::api::list_transactions(self.inner.clone(), params)
+      .await
+      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
     Ok(txns)
   }
 

--- a/bindings/swift/Sources/LNI/lni.swift
+++ b/bindings/swift/Sources/LNI/lni.swift
@@ -535,31 +535,51 @@ fileprivate struct FfiConverterString: FfiConverter {
 
 
 
+/**
+ * Backward-compatible Blink wrapper around the generic Galoy implementation.
+ *
+ * Deprecated: prefer [`crate::galoy::GaloyNode`].
+ */
 public protocol BlinkNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
+    func payOnchain(transaction: OnchainTransaction) async throws  -> PayOnchainResponse
+
+    func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions) async throws  -> PayOnchainResponse
+
+    func prepareOnchainTransaction(params: PrepareOnchainTransactionParams) async throws  -> OnchainTransaction
+
 }
+/**
+ * Backward-compatible Blink wrapper around the generic Galoy implementation.
+ *
+ * Deprecated: prefer [`crate::galoy::GaloyNode`].
+ */
 open class BlinkNode: BlinkNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
 
@@ -617,9 +637,9 @@ public convenience init(config: BlinkConfig) {
         try! rustCall { uniffi_lni_fn_free_blinknode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -636,7 +656,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -653,7 +673,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -670,14 +690,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_blinknode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_blinknode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -687,7 +724,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -704,7 +741,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_blinknode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -721,7 +775,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -738,7 +792,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -755,7 +809,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -770,10 +824,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -790,7 +844,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -807,7 +861,58 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func payOnchain(transaction: OnchainTransaction)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_blinknode_pay_onchain(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_blinknode_pay_onchain_with_options(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction),FfiConverterTypePayOnchainOptions_lower(options)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func prepareOnchainTransaction(params: PrepareOnchainTransactionParams)async throws  -> OnchainTransaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_blinknode_prepare_onchain_transaction(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePrepareOnchainTransactionParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOnchainTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 
 }
 
@@ -867,29 +972,33 @@ public func FfiConverterTypeBlinkNode_lower(_ value: BlinkNode) -> UnsafeMutable
 
 
 public protocol ClnNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class ClnNode: ClnNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -948,9 +1057,9 @@ public convenience init(config: ClnConfig) {
         try! rustCall { uniffi_lni_fn_free_clnnode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -967,7 +1076,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -984,7 +1093,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -1001,14 +1110,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_clnnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_clnnode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -1018,7 +1144,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -1035,7 +1161,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_clnnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -1052,7 +1195,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -1069,7 +1212,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -1086,7 +1229,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -1101,10 +1244,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -1121,7 +1264,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -1138,7 +1281,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -1198,34 +1341,1309 @@ public func FfiConverterTypeClnNode_lower(_ value: ClnNode) -> UnsafeMutableRawP
 
 
 /**
+ * Flash adapter backed by the generic Galoy GraphQL implementation.
+ *
+ * Status-only payments may return an empty preimage. Use
+ * [`FlashNode::pay_invoice_with_status`] when the caller must distinguish a
+ * resolved `PENDING` payment from settlement.
+ */
+public protocol FlashNodeProtocol: AnyObject, Sendable {
+
+    func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
+
+    func createOffer(params: CreateOfferParams) async throws  -> Offer
+
+    func decode(value: String) async throws  -> String
+
+    func decodeOffer(offer: String) async throws  -> String
+
+    func galoy()  -> GaloyNode
+
+    func getInfo() async throws  -> NodeInfo
+
+    func getOffer(search: String?) async throws  -> Offer
+
+    func getPermissions() async throws  -> Permissions
+
+    func listOffers(search: String?) async throws  -> [Offer]
+
+    func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
+
+    func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
+    func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
+
+    /**
+     * Pay an invoice while retaining Flash's accepted provider status.
+     */
+    func payInvoiceWithStatus(params: PayInvoiceParams) async throws  -> GaloyPaymentOutcome
+
+    func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
+
+}
+/**
+ * Flash adapter backed by the generic Galoy GraphQL implementation.
+ *
+ * Status-only payments may return an empty preimage. Use
+ * [`FlashNode::pay_invoice_with_status`] when the caller must distinguish a
+ * resolved `PENDING` payment from settlement.
+ */
+open class FlashNode: FlashNodeProtocol, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_lni_fn_clone_flashnode(self.pointer, $0) }
+    }
+public convenience init(config: FlashConfig) {
+    let pointer =
+        try! rustCall() {
+    uniffi_lni_fn_constructor_flashnode_new(
+        FfiConverterTypeFlashConfig_lower(config),$0
+    )
+}
+    self.init(unsafeFromRawPointer: pointer)
+}
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_lni_fn_free_flashnode(pointer, $0) }
+    }
+
+
+
+
+open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_create_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_create_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateOfferParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decode(value: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_decode(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(value)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func galoy() -> GaloyNode  {
+    return try!  FfiConverterTypeGaloyNode_lift(try! rustCall() {
+    uniffi_lni_fn_method_flashnode_galoy(self.uniffiClonePointer(),$0
+    )
+})
+}
+
+open func getInfo()async throws  -> NodeInfo  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_get_info(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeNodeInfo_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getOffer(search: String?)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_get_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listOffers(search: String?)async throws  -> [Offer]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_list_offers(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeOffer.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_list_transactions(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeListTransactionsParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeTransaction.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_lookup_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeLookupInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_on_invoice_events(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnInvoiceEventParams_lower(params),FfiConverterTypeOnInvoiceEventCallback_lower(callback)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_void,
+            completeFunc: ffi_lni_rust_future_complete_void,
+            freeFunc: ffi_lni_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: nil
+
+        )
+}
+
+open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_pay_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePayInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+    /**
+     * Pay an invoice while retaining Flash's accepted provider status.
+     */
+open func payInvoiceWithStatus(params: PayInvoiceParams)async throws  -> GaloyPaymentOutcome  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_pay_invoice_with_status(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePayInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeGaloyPaymentOutcome_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_flashnode_pay_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer),FfiConverterInt64.lower(amountMsats),FfiConverterOptionString.lower(payerNote)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFlashNode: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = FlashNode
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> FlashNode {
+        return FlashNode(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: FlashNode) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FlashNode {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: FlashNode, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlashNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> FlashNode {
+    return try FfiConverterTypeFlashNode.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlashNode_lower(_ value: FlashNode) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeFlashNode.lower(value)
+}
+
+
+
+
+
+
+public protocol GaloyNodeProtocol: AnyObject, Sendable {
+
+    func canCreateInvoice()  -> Bool
+
+    func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
+
+    func createOffer(params: CreateOfferParams) async throws  -> Offer
+
+    func decode(value: String) async throws  -> String
+
+    func decodeOffer(offer: String) async throws  -> String
+
+    func getInfo() async throws  -> NodeInfo
+
+    func getOffer(search: String?) async throws  -> Offer
+
+    func getPermissions() async throws  -> Permissions
+
+    func listOffers(search: String?) async throws  -> [Offer]
+
+    func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
+
+    func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
+    func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
+
+    /**
+     * Pay an invoice and retain the accepted provider status.
+     *
+     * This is additive to the shared [`crate::LightningNode::pay_invoice`] API so
+     * existing consumers of [`PayInvoiceResponse`] remain source-compatible.
+     */
+    func payInvoiceWithStatus(params: PayInvoiceParams) async throws  -> GaloyPaymentOutcome
+
+    func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
+
+    func payOnchain(transaction: OnchainTransaction) async throws  -> PayOnchainResponse
+
+    func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions) async throws  -> PayOnchainResponse
+
+    func prepareOnchainTransaction(params: PrepareOnchainTransactionParams) async throws  -> OnchainTransaction
+
+}
+open class GaloyNode: GaloyNodeProtocol, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_lni_fn_clone_galoynode(self.pointer, $0) }
+    }
+public convenience init(config: GaloyConfig) {
+    let pointer =
+        try! rustCall() {
+    uniffi_lni_fn_constructor_galoynode_new(
+        FfiConverterTypeGaloyConfig_lower(config),$0
+    )
+}
+    self.init(unsafeFromRawPointer: pointer)
+}
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_lni_fn_free_galoynode(pointer, $0) }
+    }
+
+
+
+
+open func canCreateInvoice() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_lni_fn_method_galoynode_can_create_invoice(self.uniffiClonePointer(),$0
+    )
+})
+}
+
+open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_create_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_create_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateOfferParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decode(value: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_decode(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(value)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getInfo()async throws  -> NodeInfo  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_get_info(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeNodeInfo_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getOffer(search: String?)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_get_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listOffers(search: String?)async throws  -> [Offer]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_list_offers(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeOffer.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_list_transactions(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeListTransactionsParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeTransaction.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_lookup_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeLookupInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_on_invoice_events(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnInvoiceEventParams_lower(params),FfiConverterTypeOnInvoiceEventCallback_lower(callback)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_void,
+            completeFunc: ffi_lni_rust_future_complete_void,
+            freeFunc: ffi_lni_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: nil
+
+        )
+}
+
+open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_pay_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePayInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+    /**
+     * Pay an invoice and retain the accepted provider status.
+     *
+     * This is additive to the shared [`crate::LightningNode::pay_invoice`] API so
+     * existing consumers of [`PayInvoiceResponse`] remain source-compatible.
+     */
+open func payInvoiceWithStatus(params: PayInvoiceParams)async throws  -> GaloyPaymentOutcome  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_pay_invoice_with_status(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePayInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeGaloyPaymentOutcome_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_pay_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer),FfiConverterInt64.lower(amountMsats),FfiConverterOptionString.lower(payerNote)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOnchain(transaction: OnchainTransaction)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_pay_onchain(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_pay_onchain_with_options(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction),FfiConverterTypePayOnchainOptions_lower(options)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func prepareOnchainTransaction(params: PrepareOnchainTransactionParams)async throws  -> OnchainTransaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_galoynode_prepare_onchain_transaction(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePrepareOnchainTransactionParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOnchainTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyNode: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = GaloyNode
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> GaloyNode {
+        return GaloyNode(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: GaloyNode) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyNode {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: GaloyNode, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> GaloyNode {
+    return try FfiConverterTypeGaloyNode.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyNode_lower(_ value: GaloyNode) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeGaloyNode.lower(value)
+}
+
+
+
+
+
+
+public protocol LexeNodeProtocol: AnyObject, Sendable {
+
+    func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
+
+    func createOffer(params: CreateOfferParams) async throws  -> Offer
+
+    func decode(value: String) async throws  -> String
+
+    func decodeOffer(offer: String) async throws  -> String
+
+    func getHumanBitcoinAddress() async throws  -> LexeHumanBitcoinAddress
+
+    func getInfo() async throws  -> NodeInfo
+
+    func getOffer(search: String?) async throws  -> Offer
+
+    func getPermissions() async throws  -> Permissions
+
+    func listOffers(search: String?) async throws  -> [Offer]
+
+    func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
+
+    func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
+    func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
+
+    func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
+
+}
+open class LexeNode: LexeNodeProtocol, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_lni_fn_clone_lexenode(self.pointer, $0) }
+    }
+public convenience init(config: LexeConfig)throws  {
+    let pointer =
+        try rustCallWithError(FfiConverterTypeApiError_lift) {
+    uniffi_lni_fn_constructor_lexenode_new(
+        FfiConverterTypeLexeConfig_lower(config),$0
+    )
+}
+    self.init(unsafeFromRawPointer: pointer)
+}
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_lni_fn_free_lexenode(pointer, $0) }
+    }
+
+
+
+
+open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_create_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_create_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeCreateOfferParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decode(value: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_decode(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(value)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getHumanBitcoinAddress()async throws  -> LexeHumanBitcoinAddress  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_get_human_bitcoin_address(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeLexeHumanBitcoinAddress_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getInfo()async throws  -> NodeInfo  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_get_info(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeNodeInfo_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getOffer(search: String?)async throws  -> Offer  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_get_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOffer_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listOffers(search: String?)async throws  -> [Offer]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_list_offers(
+                    self.uniffiClonePointer(),
+                    FfiConverterOptionString.lower(search)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeOffer.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_list_transactions(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeListTransactionsParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeTransaction.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_lookup_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeLookupInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_on_invoice_events(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnInvoiceEventParams_lower(params),FfiConverterTypeOnInvoiceEventCallback_lower(callback)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_void,
+            completeFunc: ffi_lni_rust_future_complete_void,
+            freeFunc: ffi_lni_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: nil
+
+        )
+}
+
+open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_pay_invoice(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePayInvoiceParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lexenode_pay_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer),FfiConverterInt64.lower(amountMsats),FfiConverterOptionString.lower(payerNote)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayInvoiceResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeLexeNode: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = LexeNode
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> LexeNode {
+        return LexeNode(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: LexeNode) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LexeNode {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: LexeNode, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> LexeNode {
+    return try FfiConverterTypeLexeNode.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeNode_lower(_ value: LexeNode) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeLexeNode.lower(value)
+}
+
+
+
+
+
+
+/**
  * The core LightningNode trait for polymorphic node operations.
  * This trait is exported to UniFFI, allowing Kotlin/Swift to work with
  * `Arc<dyn LightningNode>` directly without manual wrapper code.
  */
 public protocol LightningNode: AnyObject, Sendable {
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func decode(str: String) async throws  -> String
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
 }
 /**
  * The core LightningNode trait for polymorphic node operations.
@@ -1281,16 +2699,33 @@ open class LightningNodeImpl: LightningNode, @unchecked Sendable {
         try! rustCall { uniffi_lni_fn_free_lightningnode(pointer, $0) }
     }
 
-    
 
-    
+
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lightningnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_lightningnode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -1300,7 +2735,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -1317,7 +2752,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -1334,7 +2769,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -1351,7 +2786,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -1368,7 +2803,7 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -1385,7 +2820,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -1402,7 +2837,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -1419,7 +2854,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -1436,7 +2871,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -1453,7 +2888,24 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lightningnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -1468,10 +2920,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 
 }
 
@@ -1485,6 +2937,47 @@ fileprivate struct UniffiCallbackInterfaceLightningNode {
     // This creates 1-element array, since this seems to be the only way to construct a const
     // pointer that we can pass to the Rust code.
     static let vtable: [UniffiVTableCallbackInterfaceLightningNode] = [UniffiVTableCallbackInterfaceLightningNode(
+        getPermissions: { (
+            uniffiHandle: UInt64,
+            uniffiFutureCallback: @escaping UniffiForeignFutureCompleteRustBuffer,
+            uniffiCallbackData: UInt64,
+            uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
+        ) in
+            let makeCall = {
+                () async throws -> Permissions in
+                guard let uniffiObj = try? FfiConverterTypeLightningNode.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return try await uniffiObj.getPermissions(
+                )
+            }
+
+            let uniffiHandleSuccess = { (returnValue: Permissions) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: FfiConverterTypePermissions_lower(returnValue),
+                        callStatus: RustCallStatus()
+                    )
+                )
+            }
+            let uniffiHandleError = { (statusCode, errorBuf) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: RustBuffer.empty(),
+                        callStatus: RustCallStatus(code: statusCode, errorBuf: errorBuf)
+                    )
+                )
+            }
+            let uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                makeCall: makeCall,
+                handleSuccess: uniffiHandleSuccess,
+                handleError: uniffiHandleError,
+                lowerError: FfiConverterTypeApiError_lower
+            )
+            uniffiOutReturn.pointee = uniffiForeignFuture
+        },
         getInfo: { (
             uniffiHandle: UInt64,
             uniffiFutureCallback: @escaping UniffiForeignFutureCompleteRustBuffer,
@@ -1917,6 +3410,49 @@ fileprivate struct UniffiCallbackInterfaceLightningNode {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
+        decodeOffer: { (
+            uniffiHandle: UInt64,
+            offer: RustBuffer,
+            uniffiFutureCallback: @escaping UniffiForeignFutureCompleteRustBuffer,
+            uniffiCallbackData: UInt64,
+            uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
+        ) in
+            let makeCall = {
+                () async throws -> String in
+                guard let uniffiObj = try? FfiConverterTypeLightningNode.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return try await uniffiObj.decodeOffer(
+                     offer: try FfiConverterString.lift(offer)
+                )
+            }
+
+            let uniffiHandleSuccess = { (returnValue: String) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: FfiConverterString.lower(returnValue),
+                        callStatus: RustCallStatus()
+                    )
+                )
+            }
+            let uniffiHandleError = { (statusCode, errorBuf) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: RustBuffer.empty(),
+                        callStatus: RustCallStatus(code: statusCode, errorBuf: errorBuf)
+                    )
+                )
+            }
+            let uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                makeCall: makeCall,
+                handleSuccess: uniffiHandleSuccess,
+                handleError: uniffiHandleError,
+                lowerError: FfiConverterTypeApiError_lower
+            )
+            uniffiOutReturn.pointee = uniffiForeignFuture
+        },
         onInvoiceEvents: { (
             uniffiHandle: UInt64,
             params: RustBuffer,
@@ -2032,29 +3568,33 @@ public func FfiConverterTypeLightningNode_lower(_ value: LightningNode) -> Unsaf
 
 
 public protocol LndNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class LndNode: LndNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -2113,9 +3653,9 @@ public convenience init(config: LndConfig) {
         try! rustCall { uniffi_lni_fn_free_lndnode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -2132,7 +3672,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -2149,7 +3689,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -2166,14 +3706,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lndnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_lndnode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -2183,7 +3740,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -2200,7 +3757,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_lndnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -2217,7 +3791,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -2234,7 +3808,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -2251,7 +3825,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -2266,10 +3840,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -2286,7 +3860,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -2303,7 +3877,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -2363,29 +3937,35 @@ public func FfiConverterTypeLndNode_lower(_ value: LndNode) -> UnsafeMutableRawP
 
 
 public protocol NwcNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
+    func getLightningAddress() async throws  -> NwcLightningAddress
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class NwcNode: NwcNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -2444,9 +4024,9 @@ public convenience init(config: NwcConfig) {
         try! rustCall { uniffi_lni_fn_free_nwcnode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -2463,7 +4043,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -2480,7 +4060,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -2497,14 +4077,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_nwcnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_nwcnode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -2514,7 +4111,24 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getLightningAddress()async throws  -> NwcLightningAddress  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_nwcnode_get_lightning_address(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeNwcLightningAddress_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -2531,7 +4145,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_nwcnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -2548,7 +4179,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -2565,7 +4196,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -2582,7 +4213,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -2597,10 +4228,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -2617,7 +4248,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -2634,7 +4265,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -2694,13 +4325,13 @@ public func FfiConverterTypeNwcNode_lower(_ value: NwcNode) -> UnsafeMutableRawP
 
 
 public protocol OnInvoiceEventCallback: AnyObject, Sendable {
-    
-    func success(transaction: Transaction?) 
-    
-    func pending(transaction: Transaction?) 
-    
-    func failure(transaction: Transaction?) 
-    
+
+    func success(transaction: Transaction?)
+
+    func pending(transaction: Transaction?)
+
+    func failure(transaction: Transaction?)
+
 }
 open class OnInvoiceEventCallbackImpl: OnInvoiceEventCallback, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -2751,30 +4382,30 @@ open class OnInvoiceEventCallbackImpl: OnInvoiceEventCallback, @unchecked Sendab
         try! rustCall { uniffi_lni_fn_free_oninvoiceeventcallback(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func success(transaction: Transaction?)  {try! rustCall() {
     uniffi_lni_fn_method_oninvoiceeventcallback_success(self.uniffiClonePointer(),
         FfiConverterOptionTypeTransaction.lower(transaction),$0
     )
 }
 }
-    
+
 open func pending(transaction: Transaction?)  {try! rustCall() {
     uniffi_lni_fn_method_oninvoiceeventcallback_pending(self.uniffiClonePointer(),
         FfiConverterOptionTypeTransaction.lower(transaction),$0
     )
 }
 }
-    
+
 open func failure(transaction: Transaction?)  {try! rustCall() {
     uniffi_lni_fn_method_oninvoiceeventcallback_failure(self.uniffiClonePointer(),
         FfiConverterOptionTypeTransaction.lower(transaction),$0
     )
 }
 }
-    
+
 
 }
 
@@ -2804,7 +4435,7 @@ fileprivate struct UniffiCallbackInterfaceOnInvoiceEventCallback {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -2828,7 +4459,7 @@ fileprivate struct UniffiCallbackInterfaceOnInvoiceEventCallback {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -2852,7 +4483,7 @@ fileprivate struct UniffiCallbackInterfaceOnInvoiceEventCallback {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -2933,29 +4564,33 @@ public func FfiConverterTypeOnInvoiceEventCallback_lower(_ value: OnInvoiceEvent
 
 
 public protocol PhoenixdNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class PhoenixdNode: PhoenixdNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -3014,9 +4649,9 @@ public convenience init(config: PhoenixdConfig) {
         try! rustCall { uniffi_lni_fn_free_phoenixdnode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3033,7 +4668,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3050,7 +4685,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -3067,14 +4702,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_phoenixdnode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_phoenixdnode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -3084,7 +4736,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3101,7 +4753,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_phoenixdnode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -3118,7 +4787,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -3135,7 +4804,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3152,7 +4821,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -3167,10 +4836,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3187,7 +4856,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3204,7 +4873,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -3264,44 +4933,48 @@ public func FfiConverterTypePhoenixdNode_lower(_ value: PhoenixdNode) -> UnsafeM
 
 
 public protocol SparkNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     /**
      * Disconnect from the Spark network
      */
-    func disconnect() async throws 
-    
+    func disconnect() async throws
+
     /**
      * Get a Bitcoin address for on-chain deposits
      */
     func getDepositAddress() async throws  -> String
-    
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     /**
      * Get the Spark address for receiving payments
      */
     func getSparkAddress() async throws  -> String
-    
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class SparkNode: SparkNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -3358,7 +5031,7 @@ public convenience init(config: SparkConfig)async throws  {
             liftFunc: FfiConverterTypeSparkNode_lift,
             errorHandler: FfiConverterTypeApiError_lift
         )
-        
+
         .uniffiClonePointer()
     self.init(unsafeFromRawPointer: pointer)
 }
@@ -3371,9 +5044,9 @@ public convenience init(config: SparkConfig)async throws  {
         try! rustCall { uniffi_lni_fn_free_sparknode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3390,7 +5063,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3407,7 +5080,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -3424,37 +5097,14 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
-    /**
-     * Disconnect from the Spark network
-     */
-open func disconnect()async throws   {
+
+open func decodeOffer(offer: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_lni_fn_method_sparknode_disconnect(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_lni_rust_future_poll_void,
-            completeFunc: ffi_lni_rust_future_complete_void,
-            freeFunc: ffi_lni_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeApiError_lift
-        )
-}
-    
-    /**
-     * Get a Bitcoin address for on-chain deposits
-     */
-open func getDepositAddress()async throws  -> String  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_lni_fn_method_sparknode_get_deposit_address(
-                    self.uniffiClonePointer()
-                    
+                uniffi_lni_fn_method_sparknode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -3464,14 +5114,54 @@ open func getDepositAddress()async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+    /**
+     * Disconnect from the Spark network
+     */
+open func disconnect()async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_sparknode_disconnect(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_void,
+            completeFunc: ffi_lni_rust_future_complete_void,
+            freeFunc: ffi_lni_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+    /**
+     * Get a Bitcoin address for on-chain deposits
+     */
+open func getDepositAddress()async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_sparknode_get_deposit_address(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_sparknode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -3481,7 +5171,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3498,7 +5188,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_sparknode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
     /**
      * Get the Spark address for receiving payments
      */
@@ -3508,7 +5215,7 @@ open func getSparkAddress()async throws  -> String  {
             rustFutureFunc: {
                 uniffi_lni_fn_method_sparknode_get_spark_address(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -3518,7 +5225,7 @@ open func getSparkAddress()async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -3535,7 +5242,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -3552,7 +5259,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3569,7 +5276,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -3584,10 +5291,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3604,7 +5311,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3621,7 +5328,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -3681,29 +5388,33 @@ public func FfiConverterTypeSparkNode_lower(_ value: SparkNode) -> UnsafeMutable
 
 
 public protocol SpeedNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
 }
 open class SpeedNode: SpeedNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -3762,9 +5473,9 @@ public convenience init(config: SpeedConfig) {
         try! rustCall { uniffi_lni_fn_free_speednode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3781,7 +5492,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3798,7 +5509,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -3815,14 +5526,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_speednode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_speednode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -3832,7 +5560,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -3849,7 +5577,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_speednode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -3866,7 +5611,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -3883,7 +5628,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -3900,7 +5645,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -3915,10 +5660,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3935,7 +5680,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -3952,7 +5697,7 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 
 }
 
@@ -4012,29 +5757,39 @@ public func FfiConverterTypeSpeedNode_lower(_ value: SpeedNode) -> UnsafeMutable
 
 
 public protocol StrikeNodeProtocol: AnyObject, Sendable {
-    
+
     func createInvoice(params: CreateInvoiceParams) async throws  -> Transaction
-    
+
     func createOffer(params: CreateOfferParams) async throws  -> Offer
-    
+
     func decode(str: String) async throws  -> String
-    
+
+    func decodeOffer(offer: String) async throws  -> String
+
     func getInfo() async throws  -> NodeInfo
-    
+
     func getOffer(search: String?) async throws  -> Offer
-    
+
+    func getPermissions() async throws  -> Permissions
+
     func listOffers(search: String?) async throws  -> [Offer]
-    
+
     func listTransactions(params: ListTransactionsParams) async throws  -> [Transaction]
-    
+
     func lookupInvoice(params: LookupInvoiceParams) async throws  -> Transaction
-    
-    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async 
-    
+
+    func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback) async
+
     func payInvoice(params: PayInvoiceParams) async throws  -> PayInvoiceResponse
-    
+
     func payOffer(offer: String, amountMsats: Int64, payerNote: String?) async throws  -> PayInvoiceResponse
-    
+
+    func payOnchain(transaction: OnchainTransaction) async throws  -> PayOnchainResponse
+
+    func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions) async throws  -> PayOnchainResponse
+
+    func prepareOnchainTransaction(params: PrepareOnchainTransactionParams) async throws  -> OnchainTransaction
+
 }
 open class StrikeNode: StrikeNodeProtocol, @unchecked Sendable {
     fileprivate let pointer: UnsafeMutableRawPointer!
@@ -4093,9 +5848,9 @@ public convenience init(config: StrikeConfig) {
         try! rustCall { uniffi_lni_fn_free_strikenode(pointer, $0) }
     }
 
-    
 
-    
+
+
 open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -4112,7 +5867,7 @@ open func createInvoice(params: CreateInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -4129,7 +5884,7 @@ open func createOffer(params: CreateOfferParams)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func decode(str: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
@@ -4146,14 +5901,31 @@ open func decode(str: String)async throws  -> String  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_strikenode_decode_offer(
+                    self.uniffiClonePointer(),
+                    FfiConverterString.lower(offer)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func getInfo()async throws  -> NodeInfo  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_lni_fn_method_strikenode_get_info(
                     self.uniffiClonePointer()
-                    
+
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -4163,7 +5935,7 @@ open func getInfo()async throws  -> NodeInfo  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func getOffer(search: String?)async throws  -> Offer  {
     return
         try  await uniffiRustCallAsync(
@@ -4180,7 +5952,24 @@ open func getOffer(search: String?)async throws  -> Offer  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func getPermissions()async throws  -> Permissions  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_strikenode_get_permissions(
+                    self.uniffiClonePointer()
+
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePermissions_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 open func listOffers(search: String?)async throws  -> [Offer]  {
     return
         try  await uniffiRustCallAsync(
@@ -4197,7 +5986,7 @@ open func listOffers(search: String?)async throws  -> [Offer]  {
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func listTransactions(params: ListTransactionsParams)async throws  -> [Transaction]  {
     return
         try  await uniffiRustCallAsync(
@@ -4214,7 +6003,7 @@ open func listTransactions(params: ListTransactionsParams)async throws  -> [Tran
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -4231,7 +6020,7 @@ open func lookupInvoice(params: LookupInvoiceParams)async throws  -> Transaction
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEventCallback)async   {
     return
         try!  await uniffiRustCallAsync(
@@ -4246,10 +6035,10 @@ open func onInvoiceEvents(params: OnInvoiceEventParams, callback: OnInvoiceEvent
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -4266,7 +6055,7 @@ open func payInvoice(params: PayInvoiceParams)async throws  -> PayInvoiceRespons
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
 open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async throws  -> PayInvoiceResponse  {
     return
         try  await uniffiRustCallAsync(
@@ -4283,7 +6072,58 @@ open func payOffer(offer: String, amountMsats: Int64, payerNote: String?)async t
             errorHandler: FfiConverterTypeApiError_lift
         )
 }
-    
+
+open func payOnchain(transaction: OnchainTransaction)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_strikenode_pay_onchain(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func payOnchainWithOptions(transaction: OnchainTransaction, options: PayOnchainOptions)async throws  -> PayOnchainResponse  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_strikenode_pay_onchain_with_options(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeOnchainTransaction_lower(transaction),FfiConverterTypePayOnchainOptions_lower(options)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypePayOnchainResponse_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
+open func prepareOnchainTransaction(params: PrepareOnchainTransactionParams)async throws  -> OnchainTransaction  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_method_strikenode_prepare_onchain_transaction(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypePrepareOnchainTransactionParams_lower(params)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeOnchainTransaction_lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+
 
 }
 
@@ -4383,7 +6223,7 @@ public struct FfiConverterTypeBalancesResponse: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BalancesResponse {
         return
             try BalancesResponse(
-                onchain: FfiConverterTypeOnchainBalanceResponse.read(from: &buf), 
+                onchain: FfiConverterTypeOnchainBalanceResponse.read(from: &buf),
                 lightning: FfiConverterTypeLightningBalanceResponse.read(from: &buf)
         )
     }
@@ -4419,7 +6259,7 @@ public struct BlinkConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(baseUrl: String? = "https://api.blink.sv/graphql", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(baseUrl: String? = "https://api.blink.sv/graphql", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.baseUrl = baseUrl
         self.apiKey = apiKey
         self.socks5Proxy = socks5Proxy
@@ -4471,10 +6311,10 @@ public struct FfiConverterTypeBlinkConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlinkConfig {
         return
             try BlinkConfig(
-                baseUrl: FfiConverterOptionString.read(from: &buf), 
-                apiKey: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                baseUrl: FfiConverterOptionString.read(from: &buf),
+                apiKey: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -4637,22 +6477,22 @@ public struct FfiConverterTypeChannel: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Channel {
         return
             try Channel(
-                localBalance: FfiConverterInt64.read(from: &buf), 
-                localSpendableBalance: FfiConverterInt64.read(from: &buf), 
-                remoteBalance: FfiConverterInt64.read(from: &buf), 
-                id: FfiConverterString.read(from: &buf), 
-                remotePubkey: FfiConverterString.read(from: &buf), 
-                fundingTxId: FfiConverterString.read(from: &buf), 
-                fundingTxVout: FfiConverterInt64.read(from: &buf), 
-                active: FfiConverterBool.read(from: &buf), 
-                public: FfiConverterBool.read(from: &buf), 
-                internalChannel: FfiConverterString.read(from: &buf), 
-                confirmations: FfiConverterInt64.read(from: &buf), 
-                confirmationsRequired: FfiConverterInt64.read(from: &buf), 
-                forwardingFeeBaseMsat: FfiConverterInt64.read(from: &buf), 
-                unspendablePunishmentReserve: FfiConverterInt64.read(from: &buf), 
-                counterpartyUnspendablePunishmentReserve: FfiConverterInt64.read(from: &buf), 
-                error: FfiConverterString.read(from: &buf), 
+                localBalance: FfiConverterInt64.read(from: &buf),
+                localSpendableBalance: FfiConverterInt64.read(from: &buf),
+                remoteBalance: FfiConverterInt64.read(from: &buf),
+                id: FfiConverterString.read(from: &buf),
+                remotePubkey: FfiConverterString.read(from: &buf),
+                fundingTxId: FfiConverterString.read(from: &buf),
+                fundingTxVout: FfiConverterInt64.read(from: &buf),
+                active: FfiConverterBool.read(from: &buf),
+                public: FfiConverterBool.read(from: &buf),
+                internalChannel: FfiConverterString.read(from: &buf),
+                confirmations: FfiConverterInt64.read(from: &buf),
+                confirmationsRequired: FfiConverterInt64.read(from: &buf),
+                forwardingFeeBaseMsat: FfiConverterInt64.read(from: &buf),
+                unspendablePunishmentReserve: FfiConverterInt64.read(from: &buf),
+                counterpartyUnspendablePunishmentReserve: FfiConverterInt64.read(from: &buf),
+                error: FfiConverterString.read(from: &buf),
                 isOutbound: FfiConverterBool.read(from: &buf)
         )
     }
@@ -4755,10 +6595,10 @@ public struct FfiConverterTypeClnConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ClnConfig {
         return
             try ClnConfig(
-                url: FfiConverterString.read(from: &buf), 
-                rune: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                url: FfiConverterString.read(from: &buf),
+                rune: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -4837,8 +6677,8 @@ public struct FfiConverterTypeCloseChannelRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CloseChannelRequest {
         return
             try CloseChannelRequest(
-                channelId: FfiConverterString.read(from: &buf), 
-                nodeId: FfiConverterString.read(from: &buf), 
+                channelId: FfiConverterString.read(from: &buf),
+                nodeId: FfiConverterString.read(from: &buf),
                 force: FfiConverterBool.read(from: &buf)
         )
     }
@@ -4968,8 +6808,8 @@ public struct FfiConverterTypeConnectPeerRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectPeerRequest {
         return
             try ConnectPeerRequest(
-                pubkey: FfiConverterString.read(from: &buf), 
-                address: FfiConverterString.read(from: &buf), 
+                pubkey: FfiConverterString.read(from: &buf),
+                address: FfiConverterString.read(from: &buf),
                 port: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5100,16 +6940,16 @@ public struct FfiConverterTypeCreateInvoiceParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CreateInvoiceParams {
         return
             try CreateInvoiceParams(
-                invoiceType: FfiConverterOptionTypeInvoiceType.read(from: &buf), 
-                amountMsats: FfiConverterOptionInt64.read(from: &buf), 
-                offer: FfiConverterOptionString.read(from: &buf), 
-                description: FfiConverterOptionString.read(from: &buf), 
-                descriptionHash: FfiConverterOptionString.read(from: &buf), 
-                expiry: FfiConverterOptionInt64.read(from: &buf), 
-                rPreimage: FfiConverterOptionString.read(from: &buf), 
-                isBlinded: FfiConverterOptionBool.read(from: &buf), 
-                isKeysend: FfiConverterOptionBool.read(from: &buf), 
-                isAmp: FfiConverterOptionBool.read(from: &buf), 
+                invoiceType: FfiConverterOptionTypeInvoiceType.read(from: &buf),
+                amountMsats: FfiConverterOptionInt64.read(from: &buf),
+                offer: FfiConverterOptionString.read(from: &buf),
+                description: FfiConverterOptionString.read(from: &buf),
+                descriptionHash: FfiConverterOptionString.read(from: &buf),
+                expiry: FfiConverterOptionInt64.read(from: &buf),
+                rPreimage: FfiConverterOptionString.read(from: &buf),
+                isBlinded: FfiConverterOptionBool.read(from: &buf),
+                isKeysend: FfiConverterOptionBool.read(from: &buf),
+                isAmp: FfiConverterOptionBool.read(from: &buf),
                 isPrivate: FfiConverterOptionBool.read(from: &buf)
         )
     }
@@ -5188,7 +7028,7 @@ public struct FfiConverterTypeCreateOfferParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CreateOfferParams {
         return
             try CreateOfferParams(
-                description: FfiConverterOptionString.read(from: &buf), 
+                description: FfiConverterOptionString.read(from: &buf),
                 amountMsats: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -5212,6 +7052,927 @@ public func FfiConverterTypeCreateOfferParams_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeCreateOfferParams_lower(_ value: CreateOfferParams) -> RustBuffer {
     return FfiConverterTypeCreateOfferParams.lower(value)
+}
+
+
+public struct FlashConfig {
+    public var apiKey: String
+    public var baseUrl: String?
+    public var walletId: String
+    public var walletCurrency: String
+    public var additionalHeaders: [String: String]?
+    public var acceptedStatuses: [String]?
+    public var httpTimeout: Int64?
+    public var socks5Proxy: String?
+    public var acceptInvalidCerts: Bool?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(apiKey: String, baseUrl: String?, walletId: String, walletCurrency: String, additionalHeaders: [String: String]?, acceptedStatuses: [String]?, httpTimeout: Int64?, socks5Proxy: String?, acceptInvalidCerts: Bool?) {
+        self.apiKey = apiKey
+        self.baseUrl = baseUrl
+        self.walletId = walletId
+        self.walletCurrency = walletCurrency
+        self.additionalHeaders = additionalHeaders
+        self.acceptedStatuses = acceptedStatuses
+        self.httpTimeout = httpTimeout
+        self.socks5Proxy = socks5Proxy
+        self.acceptInvalidCerts = acceptInvalidCerts
+    }
+}
+
+#if compiler(>=6)
+extension FlashConfig: Sendable {}
+#endif
+
+
+extension FlashConfig: Equatable, Hashable {
+    public static func ==(lhs: FlashConfig, rhs: FlashConfig) -> Bool {
+        if lhs.apiKey != rhs.apiKey {
+            return false
+        }
+        if lhs.baseUrl != rhs.baseUrl {
+            return false
+        }
+        if lhs.walletId != rhs.walletId {
+            return false
+        }
+        if lhs.walletCurrency != rhs.walletCurrency {
+            return false
+        }
+        if lhs.additionalHeaders != rhs.additionalHeaders {
+            return false
+        }
+        if lhs.acceptedStatuses != rhs.acceptedStatuses {
+            return false
+        }
+        if lhs.httpTimeout != rhs.httpTimeout {
+            return false
+        }
+        if lhs.socks5Proxy != rhs.socks5Proxy {
+            return false
+        }
+        if lhs.acceptInvalidCerts != rhs.acceptInvalidCerts {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(apiKey)
+        hasher.combine(baseUrl)
+        hasher.combine(walletId)
+        hasher.combine(walletCurrency)
+        hasher.combine(additionalHeaders)
+        hasher.combine(acceptedStatuses)
+        hasher.combine(httpTimeout)
+        hasher.combine(socks5Proxy)
+        hasher.combine(acceptInvalidCerts)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFlashConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FlashConfig {
+        return
+            try FlashConfig(
+                apiKey: FfiConverterString.read(from: &buf),
+                baseUrl: FfiConverterOptionString.read(from: &buf),
+                walletId: FfiConverterString.read(from: &buf),
+                walletCurrency: FfiConverterString.read(from: &buf),
+                additionalHeaders: FfiConverterOptionDictionaryStringString.read(from: &buf),
+                acceptedStatuses: FfiConverterOptionSequenceString.read(from: &buf),
+                httpTimeout: FfiConverterOptionInt64.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FlashConfig, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.apiKey, into: &buf)
+        FfiConverterOptionString.write(value.baseUrl, into: &buf)
+        FfiConverterString.write(value.walletId, into: &buf)
+        FfiConverterString.write(value.walletCurrency, into: &buf)
+        FfiConverterOptionDictionaryStringString.write(value.additionalHeaders, into: &buf)
+        FfiConverterOptionSequenceString.write(value.acceptedStatuses, into: &buf)
+        FfiConverterOptionInt64.write(value.httpTimeout, into: &buf)
+        FfiConverterOptionString.write(value.socks5Proxy, into: &buf)
+        FfiConverterOptionBool.write(value.acceptInvalidCerts, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlashConfig_lift(_ buf: RustBuffer) throws -> FlashConfig {
+    return try FfiConverterTypeFlashConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFlashConfig_lower(_ value: FlashConfig) -> RustBuffer {
+    return FfiConverterTypeFlashConfig.lower(value)
+}
+
+
+public struct GaloyCapabilities {
+    public var transactionLookup: Bool
+    public var transactionHistory: Bool
+    public var invoiceEvents: Bool
+    public var onchain: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(transactionLookup: Bool, transactionHistory: Bool, invoiceEvents: Bool, onchain: Bool) {
+        self.transactionLookup = transactionLookup
+        self.transactionHistory = transactionHistory
+        self.invoiceEvents = invoiceEvents
+        self.onchain = onchain
+    }
+}
+
+#if compiler(>=6)
+extension GaloyCapabilities: Sendable {}
+#endif
+
+
+extension GaloyCapabilities: Equatable, Hashable {
+    public static func ==(lhs: GaloyCapabilities, rhs: GaloyCapabilities) -> Bool {
+        if lhs.transactionLookup != rhs.transactionLookup {
+            return false
+        }
+        if lhs.transactionHistory != rhs.transactionHistory {
+            return false
+        }
+        if lhs.invoiceEvents != rhs.invoiceEvents {
+            return false
+        }
+        if lhs.onchain != rhs.onchain {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(transactionLookup)
+        hasher.combine(transactionHistory)
+        hasher.combine(invoiceEvents)
+        hasher.combine(onchain)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyCapabilities: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyCapabilities {
+        return
+            try GaloyCapabilities(
+                transactionLookup: FfiConverterBool.read(from: &buf),
+                transactionHistory: FfiConverterBool.read(from: &buf),
+                invoiceEvents: FfiConverterBool.read(from: &buf),
+                onchain: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyCapabilities, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.transactionLookup, into: &buf)
+        FfiConverterBool.write(value.transactionHistory, into: &buf)
+        FfiConverterBool.write(value.invoiceEvents, into: &buf)
+        FfiConverterBool.write(value.onchain, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyCapabilities_lift(_ buf: RustBuffer) throws -> GaloyCapabilities {
+    return try FfiConverterTypeGaloyCapabilities.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyCapabilities_lower(_ value: GaloyCapabilities) -> RustBuffer {
+    return FfiConverterTypeGaloyCapabilities.lower(value)
+}
+
+
+public struct GaloyConfig {
+    public var apiKey: String
+    public var baseUrl: String
+    public var provider: GaloyProvider
+    public var wallet: GaloyWalletConfig
+    public var invoiceOperations: GaloyInvoiceOperationsConfig
+    public var payment: GaloyPaymentConfig
+    public var capabilities: GaloyCapabilities
+    public var permissions: GaloyPermissionsMode
+    public var additionalHeaders: [String: String]?
+    public var httpTimeout: Int64?
+    public var socks5Proxy: String?
+    public var acceptInvalidCerts: Bool?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(apiKey: String, baseUrl: String, provider: GaloyProvider, wallet: GaloyWalletConfig, invoiceOperations: GaloyInvoiceOperationsConfig, payment: GaloyPaymentConfig, capabilities: GaloyCapabilities, permissions: GaloyPermissionsMode, additionalHeaders: [String: String]?, httpTimeout: Int64?, socks5Proxy: String?, acceptInvalidCerts: Bool?) {
+        self.apiKey = apiKey
+        self.baseUrl = baseUrl
+        self.provider = provider
+        self.wallet = wallet
+        self.invoiceOperations = invoiceOperations
+        self.payment = payment
+        self.capabilities = capabilities
+        self.permissions = permissions
+        self.additionalHeaders = additionalHeaders
+        self.httpTimeout = httpTimeout
+        self.socks5Proxy = socks5Proxy
+        self.acceptInvalidCerts = acceptInvalidCerts
+    }
+}
+
+#if compiler(>=6)
+extension GaloyConfig: Sendable {}
+#endif
+
+
+extension GaloyConfig: Equatable, Hashable {
+    public static func ==(lhs: GaloyConfig, rhs: GaloyConfig) -> Bool {
+        if lhs.apiKey != rhs.apiKey {
+            return false
+        }
+        if lhs.baseUrl != rhs.baseUrl {
+            return false
+        }
+        if lhs.provider != rhs.provider {
+            return false
+        }
+        if lhs.wallet != rhs.wallet {
+            return false
+        }
+        if lhs.invoiceOperations != rhs.invoiceOperations {
+            return false
+        }
+        if lhs.payment != rhs.payment {
+            return false
+        }
+        if lhs.capabilities != rhs.capabilities {
+            return false
+        }
+        if lhs.permissions != rhs.permissions {
+            return false
+        }
+        if lhs.additionalHeaders != rhs.additionalHeaders {
+            return false
+        }
+        if lhs.httpTimeout != rhs.httpTimeout {
+            return false
+        }
+        if lhs.socks5Proxy != rhs.socks5Proxy {
+            return false
+        }
+        if lhs.acceptInvalidCerts != rhs.acceptInvalidCerts {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(apiKey)
+        hasher.combine(baseUrl)
+        hasher.combine(provider)
+        hasher.combine(wallet)
+        hasher.combine(invoiceOperations)
+        hasher.combine(payment)
+        hasher.combine(capabilities)
+        hasher.combine(permissions)
+        hasher.combine(additionalHeaders)
+        hasher.combine(httpTimeout)
+        hasher.combine(socks5Proxy)
+        hasher.combine(acceptInvalidCerts)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyConfig {
+        return
+            try GaloyConfig(
+                apiKey: FfiConverterString.read(from: &buf),
+                baseUrl: FfiConverterString.read(from: &buf),
+                provider: FfiConverterTypeGaloyProvider.read(from: &buf),
+                wallet: FfiConverterTypeGaloyWalletConfig.read(from: &buf),
+                invoiceOperations: FfiConverterTypeGaloyInvoiceOperationsConfig.read(from: &buf),
+                payment: FfiConverterTypeGaloyPaymentConfig.read(from: &buf),
+                capabilities: FfiConverterTypeGaloyCapabilities.read(from: &buf),
+                permissions: FfiConverterTypeGaloyPermissionsMode.read(from: &buf),
+                additionalHeaders: FfiConverterOptionDictionaryStringString.read(from: &buf),
+                httpTimeout: FfiConverterOptionInt64.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyConfig, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.apiKey, into: &buf)
+        FfiConverterString.write(value.baseUrl, into: &buf)
+        FfiConverterTypeGaloyProvider.write(value.provider, into: &buf)
+        FfiConverterTypeGaloyWalletConfig.write(value.wallet, into: &buf)
+        FfiConverterTypeGaloyInvoiceOperationsConfig.write(value.invoiceOperations, into: &buf)
+        FfiConverterTypeGaloyPaymentConfig.write(value.payment, into: &buf)
+        FfiConverterTypeGaloyCapabilities.write(value.capabilities, into: &buf)
+        FfiConverterTypeGaloyPermissionsMode.write(value.permissions, into: &buf)
+        FfiConverterOptionDictionaryStringString.write(value.additionalHeaders, into: &buf)
+        FfiConverterOptionInt64.write(value.httpTimeout, into: &buf)
+        FfiConverterOptionString.write(value.socks5Proxy, into: &buf)
+        FfiConverterOptionBool.write(value.acceptInvalidCerts, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyConfig_lift(_ buf: RustBuffer) throws -> GaloyConfig {
+    return try FfiConverterTypeGaloyConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyConfig_lower(_ value: GaloyConfig) -> RustBuffer {
+    return FfiConverterTypeGaloyConfig.lower(value)
+}
+
+
+public struct GaloyInvoiceOperationsConfig {
+    public var create: GaloyInvoiceOperation
+    public var feeProbe: GaloyInvoiceOperation
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(create: GaloyInvoiceOperation, feeProbe: GaloyInvoiceOperation) {
+        self.create = create
+        self.feeProbe = feeProbe
+    }
+}
+
+#if compiler(>=6)
+extension GaloyInvoiceOperationsConfig: Sendable {}
+#endif
+
+
+extension GaloyInvoiceOperationsConfig: Equatable, Hashable {
+    public static func ==(lhs: GaloyInvoiceOperationsConfig, rhs: GaloyInvoiceOperationsConfig) -> Bool {
+        if lhs.create != rhs.create {
+            return false
+        }
+        if lhs.feeProbe != rhs.feeProbe {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(create)
+        hasher.combine(feeProbe)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyInvoiceOperationsConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyInvoiceOperationsConfig {
+        return
+            try GaloyInvoiceOperationsConfig(
+                create: FfiConverterTypeGaloyInvoiceOperation.read(from: &buf),
+                feeProbe: FfiConverterTypeGaloyInvoiceOperation.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyInvoiceOperationsConfig, into buf: inout [UInt8]) {
+        FfiConverterTypeGaloyInvoiceOperation.write(value.create, into: &buf)
+        FfiConverterTypeGaloyInvoiceOperation.write(value.feeProbe, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyInvoiceOperationsConfig_lift(_ buf: RustBuffer) throws -> GaloyInvoiceOperationsConfig {
+    return try FfiConverterTypeGaloyInvoiceOperationsConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyInvoiceOperationsConfig_lower(_ value: GaloyInvoiceOperationsConfig) -> RustBuffer {
+    return FfiConverterTypeGaloyInvoiceOperationsConfig.lower(value)
+}
+
+
+public struct GaloyPaymentConfig {
+    public var response: GaloyPaymentResponse
+    public var acceptedStatuses: [String]
+    public var statusMapping: GaloyPaymentStatusMapping?
+    public var proofUnavailableErrorCodes: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(response: GaloyPaymentResponse, acceptedStatuses: [String], statusMapping: GaloyPaymentStatusMapping?, proofUnavailableErrorCodes: [String]) {
+        self.response = response
+        self.acceptedStatuses = acceptedStatuses
+        self.statusMapping = statusMapping
+        self.proofUnavailableErrorCodes = proofUnavailableErrorCodes
+    }
+}
+
+#if compiler(>=6)
+extension GaloyPaymentConfig: Sendable {}
+#endif
+
+
+extension GaloyPaymentConfig: Equatable, Hashable {
+    public static func ==(lhs: GaloyPaymentConfig, rhs: GaloyPaymentConfig) -> Bool {
+        if lhs.response != rhs.response {
+            return false
+        }
+        if lhs.acceptedStatuses != rhs.acceptedStatuses {
+            return false
+        }
+        if lhs.statusMapping != rhs.statusMapping {
+            return false
+        }
+        if lhs.proofUnavailableErrorCodes != rhs.proofUnavailableErrorCodes {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(response)
+        hasher.combine(acceptedStatuses)
+        hasher.combine(statusMapping)
+        hasher.combine(proofUnavailableErrorCodes)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPaymentConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPaymentConfig {
+        return
+            try GaloyPaymentConfig(
+                response: FfiConverterTypeGaloyPaymentResponse.read(from: &buf),
+                acceptedStatuses: FfiConverterSequenceString.read(from: &buf),
+                statusMapping: FfiConverterOptionTypeGaloyPaymentStatusMapping.read(from: &buf),
+                proofUnavailableErrorCodes: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyPaymentConfig, into buf: inout [UInt8]) {
+        FfiConverterTypeGaloyPaymentResponse.write(value.response, into: &buf)
+        FfiConverterSequenceString.write(value.acceptedStatuses, into: &buf)
+        FfiConverterOptionTypeGaloyPaymentStatusMapping.write(value.statusMapping, into: &buf)
+        FfiConverterSequenceString.write(value.proofUnavailableErrorCodes, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentConfig_lift(_ buf: RustBuffer) throws -> GaloyPaymentConfig {
+    return try FfiConverterTypeGaloyPaymentConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentConfig_lower(_ value: GaloyPaymentConfig) -> RustBuffer {
+    return FfiConverterTypeGaloyPaymentConfig.lower(value)
+}
+
+
+public struct GaloyPaymentOutcome {
+    public var payment: PayInvoiceResponse
+    public var state: GaloyPaymentState
+    public var providerStatus: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(payment: PayInvoiceResponse, state: GaloyPaymentState, providerStatus: String) {
+        self.payment = payment
+        self.state = state
+        self.providerStatus = providerStatus
+    }
+}
+
+#if compiler(>=6)
+extension GaloyPaymentOutcome: Sendable {}
+#endif
+
+
+extension GaloyPaymentOutcome: Equatable, Hashable {
+    public static func ==(lhs: GaloyPaymentOutcome, rhs: GaloyPaymentOutcome) -> Bool {
+        if lhs.payment != rhs.payment {
+            return false
+        }
+        if lhs.state != rhs.state {
+            return false
+        }
+        if lhs.providerStatus != rhs.providerStatus {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(payment)
+        hasher.combine(state)
+        hasher.combine(providerStatus)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPaymentOutcome: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPaymentOutcome {
+        return
+            try GaloyPaymentOutcome(
+                payment: FfiConverterTypePayInvoiceResponse.read(from: &buf),
+                state: FfiConverterTypeGaloyPaymentState.read(from: &buf),
+                providerStatus: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyPaymentOutcome, into buf: inout [UInt8]) {
+        FfiConverterTypePayInvoiceResponse.write(value.payment, into: &buf)
+        FfiConverterTypeGaloyPaymentState.write(value.state, into: &buf)
+        FfiConverterString.write(value.providerStatus, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentOutcome_lift(_ buf: RustBuffer) throws -> GaloyPaymentOutcome {
+    return try FfiConverterTypeGaloyPaymentOutcome.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentOutcome_lower(_ value: GaloyPaymentOutcome) -> RustBuffer {
+    return FfiConverterTypeGaloyPaymentOutcome.lower(value)
+}
+
+
+public struct GaloyPaymentStatusMapping {
+    public var settled: [String]
+    public var pending: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(settled: [String], pending: [String]) {
+        self.settled = settled
+        self.pending = pending
+    }
+}
+
+#if compiler(>=6)
+extension GaloyPaymentStatusMapping: Sendable {}
+#endif
+
+
+extension GaloyPaymentStatusMapping: Equatable, Hashable {
+    public static func ==(lhs: GaloyPaymentStatusMapping, rhs: GaloyPaymentStatusMapping) -> Bool {
+        if lhs.settled != rhs.settled {
+            return false
+        }
+        if lhs.pending != rhs.pending {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(settled)
+        hasher.combine(pending)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPaymentStatusMapping: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPaymentStatusMapping {
+        return
+            try GaloyPaymentStatusMapping(
+                settled: FfiConverterSequenceString.read(from: &buf),
+                pending: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyPaymentStatusMapping, into buf: inout [UInt8]) {
+        FfiConverterSequenceString.write(value.settled, into: &buf)
+        FfiConverterSequenceString.write(value.pending, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentStatusMapping_lift(_ buf: RustBuffer) throws -> GaloyPaymentStatusMapping {
+    return try FfiConverterTypeGaloyPaymentStatusMapping.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentStatusMapping_lower(_ value: GaloyPaymentStatusMapping) -> RustBuffer {
+    return FfiConverterTypeGaloyPaymentStatusMapping.lower(value)
+}
+
+
+public struct GaloyProvider {
+    public var id: String
+    public var name: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+#if compiler(>=6)
+extension GaloyProvider: Sendable {}
+#endif
+
+
+extension GaloyProvider: Equatable, Hashable {
+    public static func ==(lhs: GaloyProvider, rhs: GaloyProvider) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.name != rhs.name {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyProvider: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyProvider {
+        return
+            try GaloyProvider(
+                id: FfiConverterString.read(from: &buf),
+                name: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GaloyProvider, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.name, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyProvider_lift(_ buf: RustBuffer) throws -> GaloyProvider {
+    return try FfiConverterTypeGaloyProvider.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyProvider_lower(_ value: GaloyProvider) -> RustBuffer {
+    return FfiConverterTypeGaloyProvider.lower(value)
+}
+
+
+public struct LexeConfig {
+    /**
+     * Portable client credentials exported by the Lexe app.
+     */
+    public var clientCredentials: String
+    /**
+     * Base directory for Lexe's local payment cache.
+     */
+    public var dataDir: String?
+    /**
+     * `mainnet` (default), `testnet`, or `testnet3`.
+     */
+    public var network: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Portable client credentials exported by the Lexe app.
+         */clientCredentials: String,
+        /**
+         * Base directory for Lexe's local payment cache.
+         */dataDir: String? = nil,
+        /**
+         * `mainnet` (default), `testnet`, or `testnet3`.
+         */network: String? = "mainnet") {
+        self.clientCredentials = clientCredentials
+        self.dataDir = dataDir
+        self.network = network
+    }
+}
+
+#if compiler(>=6)
+extension LexeConfig: Sendable {}
+#endif
+
+
+extension LexeConfig: Equatable, Hashable {
+    public static func ==(lhs: LexeConfig, rhs: LexeConfig) -> Bool {
+        if lhs.clientCredentials != rhs.clientCredentials {
+            return false
+        }
+        if lhs.dataDir != rhs.dataDir {
+            return false
+        }
+        if lhs.network != rhs.network {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(clientCredentials)
+        hasher.combine(dataDir)
+        hasher.combine(network)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeLexeConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LexeConfig {
+        return
+            try LexeConfig(
+                clientCredentials: FfiConverterString.read(from: &buf),
+                dataDir: FfiConverterOptionString.read(from: &buf),
+                network: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: LexeConfig, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.clientCredentials, into: &buf)
+        FfiConverterOptionString.write(value.dataDir, into: &buf)
+        FfiConverterOptionString.write(value.network, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeConfig_lift(_ buf: RustBuffer) throws -> LexeConfig {
+    return try FfiConverterTypeLexeConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeConfig_lower(_ value: LexeConfig) -> RustBuffer {
+    return FfiConverterTypeLexeConfig.lower(value)
+}
+
+
+/**
+ * Lexe's human-readable Bitcoin and Lightning receiving addresses.
+ */
+public struct LexeHumanBitcoinAddress {
+    public var humanBitcoinAddress: String
+    public var lightningAddress: String
+    public var offer: String
+    public var updatable: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(humanBitcoinAddress: String, lightningAddress: String, offer: String, updatable: Bool) {
+        self.humanBitcoinAddress = humanBitcoinAddress
+        self.lightningAddress = lightningAddress
+        self.offer = offer
+        self.updatable = updatable
+    }
+}
+
+#if compiler(>=6)
+extension LexeHumanBitcoinAddress: Sendable {}
+#endif
+
+
+extension LexeHumanBitcoinAddress: Equatable, Hashable {
+    public static func ==(lhs: LexeHumanBitcoinAddress, rhs: LexeHumanBitcoinAddress) -> Bool {
+        if lhs.humanBitcoinAddress != rhs.humanBitcoinAddress {
+            return false
+        }
+        if lhs.lightningAddress != rhs.lightningAddress {
+            return false
+        }
+        if lhs.offer != rhs.offer {
+            return false
+        }
+        if lhs.updatable != rhs.updatable {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(humanBitcoinAddress)
+        hasher.combine(lightningAddress)
+        hasher.combine(offer)
+        hasher.combine(updatable)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeLexeHumanBitcoinAddress: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LexeHumanBitcoinAddress {
+        return
+            try LexeHumanBitcoinAddress(
+                humanBitcoinAddress: FfiConverterString.read(from: &buf),
+                lightningAddress: FfiConverterString.read(from: &buf),
+                offer: FfiConverterString.read(from: &buf),
+                updatable: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: LexeHumanBitcoinAddress, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.humanBitcoinAddress, into: &buf)
+        FfiConverterString.write(value.lightningAddress, into: &buf)
+        FfiConverterString.write(value.offer, into: &buf)
+        FfiConverterBool.write(value.updatable, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeHumanBitcoinAddress_lift(_ buf: RustBuffer) throws -> LexeHumanBitcoinAddress {
+    return try FfiConverterTypeLexeHumanBitcoinAddress.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeLexeHumanBitcoinAddress_lower(_ value: LexeHumanBitcoinAddress) -> RustBuffer {
+    return FfiConverterTypeLexeHumanBitcoinAddress.lower(value)
 }
 
 
@@ -5282,11 +8043,11 @@ public struct FfiConverterTypeLightningBalanceResponse: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LightningBalanceResponse {
         return
             try LightningBalanceResponse(
-                totalSpendable: FfiConverterInt64.read(from: &buf), 
-                totalReceivable: FfiConverterInt64.read(from: &buf), 
-                nextMaxSpendable: FfiConverterInt64.read(from: &buf), 
-                nextMaxReceivable: FfiConverterInt64.read(from: &buf), 
-                nextMaxSpendableMpp: FfiConverterInt64.read(from: &buf), 
+                totalSpendable: FfiConverterInt64.read(from: &buf),
+                totalReceivable: FfiConverterInt64.read(from: &buf),
+                nextMaxSpendable: FfiConverterInt64.read(from: &buf),
+                nextMaxReceivable: FfiConverterInt64.read(from: &buf),
+                nextMaxSpendableMpp: FfiConverterInt64.read(from: &buf),
                 nextMaxReceivableMpp: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5322,14 +8083,18 @@ public struct ListTransactionsParams {
     public var limit: Int64
     public var paymentHash: String?
     public var search: String?
+    public var createdAfter: Int64?
+    public var createdBefore: Int64?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(from: Int64, limit: Int64, paymentHash: String?, search: String?) {
+    public init(from: Int64, limit: Int64, paymentHash: String?, search: String?, createdAfter: Int64? = nil, createdBefore: Int64? = nil) {
         self.from = from
         self.limit = limit
         self.paymentHash = paymentHash
         self.search = search
+        self.createdAfter = createdAfter
+        self.createdBefore = createdBefore
     }
 }
 
@@ -5352,6 +8117,12 @@ extension ListTransactionsParams: Equatable, Hashable {
         if lhs.search != rhs.search {
             return false
         }
+        if lhs.createdAfter != rhs.createdAfter {
+            return false
+        }
+        if lhs.createdBefore != rhs.createdBefore {
+            return false
+        }
         return true
     }
 
@@ -5360,6 +8131,8 @@ extension ListTransactionsParams: Equatable, Hashable {
         hasher.combine(limit)
         hasher.combine(paymentHash)
         hasher.combine(search)
+        hasher.combine(createdAfter)
+        hasher.combine(createdBefore)
     }
 }
 
@@ -5372,10 +8145,12 @@ public struct FfiConverterTypeListTransactionsParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ListTransactionsParams {
         return
             try ListTransactionsParams(
-                from: FfiConverterInt64.read(from: &buf), 
-                limit: FfiConverterInt64.read(from: &buf), 
-                paymentHash: FfiConverterOptionString.read(from: &buf), 
-                search: FfiConverterOptionString.read(from: &buf)
+                from: FfiConverterInt64.read(from: &buf),
+                limit: FfiConverterInt64.read(from: &buf),
+                paymentHash: FfiConverterOptionString.read(from: &buf),
+                search: FfiConverterOptionString.read(from: &buf),
+                createdAfter: FfiConverterOptionInt64.read(from: &buf),
+                createdBefore: FfiConverterOptionInt64.read(from: &buf)
         )
     }
 
@@ -5384,6 +8159,8 @@ public struct FfiConverterTypeListTransactionsParams: FfiConverterRustBuffer {
         FfiConverterInt64.write(value.limit, into: &buf)
         FfiConverterOptionString.write(value.paymentHash, into: &buf)
         FfiConverterOptionString.write(value.search, into: &buf)
+        FfiConverterOptionInt64.write(value.createdAfter, into: &buf)
+        FfiConverterOptionInt64.write(value.createdBefore, into: &buf)
     }
 }
 
@@ -5412,7 +8189,7 @@ public struct LndConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(url: String, macaroon: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(url: String, macaroon: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.url = url
         self.macaroon = macaroon
         self.socks5Proxy = socks5Proxy
@@ -5464,10 +8241,10 @@ public struct FfiConverterTypeLndConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LndConfig {
         return
             try LndConfig(
-                url: FfiConverterString.read(from: &buf), 
-                macaroon: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                url: FfiConverterString.read(from: &buf),
+                macaroon: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -5540,7 +8317,7 @@ public struct FfiConverterTypeLookupInvoiceParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LookupInvoiceParams {
         return
             try LookupInvoiceParams(
-                paymentHash: FfiConverterOptionString.read(from: &buf), 
+                paymentHash: FfiConverterOptionString.read(from: &buf),
                 search: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -5616,8 +8393,8 @@ public struct FfiConverterTypeNodeConnectionInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NodeConnectionInfo {
         return
             try NodeConnectionInfo(
-                pubkey: FfiConverterString.read(from: &buf), 
-                address: FfiConverterString.read(from: &buf), 
+                pubkey: FfiConverterString.read(from: &buf),
+                address: FfiConverterString.read(from: &buf),
                 port: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5754,18 +8531,18 @@ public struct FfiConverterTypeNodeInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NodeInfo {
         return
             try NodeInfo(
-                alias: FfiConverterString.read(from: &buf), 
-                color: FfiConverterString.read(from: &buf), 
-                pubkey: FfiConverterString.read(from: &buf), 
-                network: FfiConverterString.read(from: &buf), 
-                blockHeight: FfiConverterInt64.read(from: &buf), 
-                blockHash: FfiConverterString.read(from: &buf), 
-                sendBalanceMsat: FfiConverterInt64.read(from: &buf), 
-                receiveBalanceMsat: FfiConverterInt64.read(from: &buf), 
-                feeCreditBalanceMsat: FfiConverterInt64.read(from: &buf), 
-                unsettledSendBalanceMsat: FfiConverterInt64.read(from: &buf), 
-                unsettledReceiveBalanceMsat: FfiConverterInt64.read(from: &buf), 
-                pendingOpenSendBalance: FfiConverterInt64.read(from: &buf), 
+                alias: FfiConverterString.read(from: &buf),
+                color: FfiConverterString.read(from: &buf),
+                pubkey: FfiConverterString.read(from: &buf),
+                network: FfiConverterString.read(from: &buf),
+                blockHeight: FfiConverterInt64.read(from: &buf),
+                blockHash: FfiConverterString.read(from: &buf),
+                sendBalanceMsat: FfiConverterInt64.read(from: &buf),
+                receiveBalanceMsat: FfiConverterInt64.read(from: &buf),
+                feeCreditBalanceMsat: FfiConverterInt64.read(from: &buf),
+                unsettledSendBalanceMsat: FfiConverterInt64.read(from: &buf),
+                unsettledReceiveBalanceMsat: FfiConverterInt64.read(from: &buf),
+                pendingOpenSendBalance: FfiConverterInt64.read(from: &buf),
                 pendingOpenReceiveBalance: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5846,7 +8623,7 @@ public struct FfiConverterTypeNodeStatus: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NodeStatus {
         return
             try NodeStatus(
-                isReady: FfiConverterBool.read(from: &buf), 
+                isReady: FfiConverterBool.read(from: &buf),
                 internalNodeStatus: FfiConverterString.read(from: &buf)
         )
     }
@@ -5881,7 +8658,7 @@ public struct NwcConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(nwcUri: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(nwcUri: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.nwcUri = nwcUri
         self.socks5Proxy = socks5Proxy
         self.acceptInvalidCerts = acceptInvalidCerts
@@ -5928,9 +8705,9 @@ public struct FfiConverterTypeNwcConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NwcConfig {
         return
             try NwcConfig(
-                nwcUri: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                nwcUri: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -5956,6 +8733,76 @@ public func FfiConverterTypeNwcConfig_lift(_ buf: RustBuffer) throws -> NwcConfi
 #endif
 public func FfiConverterTypeNwcConfig_lower(_ value: NwcConfig) -> RustBuffer {
     return FfiConverterTypeNwcConfig.lower(value)
+}
+
+
+public struct NwcLightningAddress {
+    public var lightningAddress: String
+    public var lnurlVerifySupported: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(lightningAddress: String, lnurlVerifySupported: Bool) {
+        self.lightningAddress = lightningAddress
+        self.lnurlVerifySupported = lnurlVerifySupported
+    }
+}
+
+#if compiler(>=6)
+extension NwcLightningAddress: Sendable {}
+#endif
+
+
+extension NwcLightningAddress: Equatable, Hashable {
+    public static func ==(lhs: NwcLightningAddress, rhs: NwcLightningAddress) -> Bool {
+        if lhs.lightningAddress != rhs.lightningAddress {
+            return false
+        }
+        if lhs.lnurlVerifySupported != rhs.lnurlVerifySupported {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(lightningAddress)
+        hasher.combine(lnurlVerifySupported)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeNwcLightningAddress: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NwcLightningAddress {
+        return
+            try NwcLightningAddress(
+                lightningAddress: FfiConverterString.read(from: &buf),
+                lnurlVerifySupported: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: NwcLightningAddress, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.lightningAddress, into: &buf)
+        FfiConverterBool.write(value.lnurlVerifySupported, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNwcLightningAddress_lift(_ buf: RustBuffer) throws -> NwcLightningAddress {
+    return try FfiConverterTypeNwcLightningAddress.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeNwcLightningAddress_lower(_ value: NwcLightningAddress) -> RustBuffer {
+    return FfiConverterTypeNwcLightningAddress.lower(value)
 }
 
 
@@ -6032,12 +8879,12 @@ public struct FfiConverterTypeOffer: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Offer {
         return
             try Offer(
-                offerId: FfiConverterString.read(from: &buf), 
-                bolt12: FfiConverterString.read(from: &buf), 
-                label: FfiConverterOptionString.read(from: &buf), 
-                active: FfiConverterOptionBool.read(from: &buf), 
-                singleUse: FfiConverterOptionBool.read(from: &buf), 
-                used: FfiConverterOptionBool.read(from: &buf), 
+                offerId: FfiConverterString.read(from: &buf),
+                bolt12: FfiConverterString.read(from: &buf),
+                label: FfiConverterOptionString.read(from: &buf),
+                active: FfiConverterOptionBool.read(from: &buf),
+                singleUse: FfiConverterOptionBool.read(from: &buf),
+                used: FfiConverterOptionBool.read(from: &buf),
                 amountMsats: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -6124,9 +8971,9 @@ public struct FfiConverterTypeOnInvoiceEventParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnInvoiceEventParams {
         return
             try OnInvoiceEventParams(
-                paymentHash: FfiConverterOptionString.read(from: &buf), 
-                search: FfiConverterOptionString.read(from: &buf), 
-                pollingDelaySec: FfiConverterInt64.read(from: &buf), 
+                paymentHash: FfiConverterOptionString.read(from: &buf),
+                search: FfiConverterOptionString.read(from: &buf),
+                pollingDelaySec: FfiConverterInt64.read(from: &buf),
                 maxPollingSec: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -6222,11 +9069,11 @@ public struct FfiConverterTypeOnchainBalanceResponse: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainBalanceResponse {
         return
             try OnchainBalanceResponse(
-                spendable: FfiConverterInt64.read(from: &buf), 
-                total: FfiConverterInt64.read(from: &buf), 
-                reserved: FfiConverterInt64.read(from: &buf), 
-                pendingBalancesFromChannelClosures: FfiConverterInt64.read(from: &buf), 
-                pendingBalancesDetails: FfiConverterSequenceTypePendingBalanceDetails.read(from: &buf), 
+                spendable: FfiConverterInt64.read(from: &buf),
+                total: FfiConverterInt64.read(from: &buf),
+                reserved: FfiConverterInt64.read(from: &buf),
+                pendingBalancesFromChannelClosures: FfiConverterInt64.read(from: &buf),
+                pendingBalancesDetails: FfiConverterSequenceTypePendingBalanceDetails.read(from: &buf),
                 internalBalances: FfiConverterString.read(from: &buf)
         )
     }
@@ -6254,6 +9101,312 @@ public func FfiConverterTypeOnchainBalanceResponse_lift(_ buf: RustBuffer) throw
 #endif
 public func FfiConverterTypeOnchainBalanceResponse_lower(_ value: OnchainBalanceResponse) -> RustBuffer {
     return FfiConverterTypeOnchainBalanceResponse.lower(value)
+}
+
+
+public struct OnchainFeeGuardrail {
+    public var maxFeeSats: Int64?
+    public var maxFeePercent: Double?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(maxFeeSats: Int64? = nil, maxFeePercent: Double? = nil) {
+        self.maxFeeSats = maxFeeSats
+        self.maxFeePercent = maxFeePercent
+    }
+}
+
+#if compiler(>=6)
+extension OnchainFeeGuardrail: Sendable {}
+#endif
+
+
+extension OnchainFeeGuardrail: Equatable, Hashable {
+    public static func ==(lhs: OnchainFeeGuardrail, rhs: OnchainFeeGuardrail) -> Bool {
+        if lhs.maxFeeSats != rhs.maxFeeSats {
+            return false
+        }
+        if lhs.maxFeePercent != rhs.maxFeePercent {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(maxFeeSats)
+        hasher.combine(maxFeePercent)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainFeeGuardrail: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainFeeGuardrail {
+        return
+            try OnchainFeeGuardrail(
+                maxFeeSats: FfiConverterOptionInt64.read(from: &buf),
+                maxFeePercent: FfiConverterOptionDouble.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: OnchainFeeGuardrail, into buf: inout [UInt8]) {
+        FfiConverterOptionInt64.write(value.maxFeeSats, into: &buf)
+        FfiConverterOptionDouble.write(value.maxFeePercent, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeeGuardrail_lift(_ buf: RustBuffer) throws -> OnchainFeeGuardrail {
+    return try FfiConverterTypeOnchainFeeGuardrail.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeeGuardrail_lower(_ value: OnchainFeeGuardrail) -> RustBuffer {
+    return FfiConverterTypeOnchainFeeGuardrail.lower(value)
+}
+
+
+public struct OnchainFeePreference {
+    public var preferenceType: OnchainFeePreferenceType
+    public var speed: OnchainFeeSpeed?
+    public var targetConf: Int64?
+    public var satsPerVbyte: Double?
+    public var backend: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(preferenceType: OnchainFeePreferenceType, speed: OnchainFeeSpeed? = nil, targetConf: Int64? = nil, satsPerVbyte: Double? = nil, backend: String? = nil) {
+        self.preferenceType = preferenceType
+        self.speed = speed
+        self.targetConf = targetConf
+        self.satsPerVbyte = satsPerVbyte
+        self.backend = backend
+    }
+}
+
+#if compiler(>=6)
+extension OnchainFeePreference: Sendable {}
+#endif
+
+
+extension OnchainFeePreference: Equatable, Hashable {
+    public static func ==(lhs: OnchainFeePreference, rhs: OnchainFeePreference) -> Bool {
+        if lhs.preferenceType != rhs.preferenceType {
+            return false
+        }
+        if lhs.speed != rhs.speed {
+            return false
+        }
+        if lhs.targetConf != rhs.targetConf {
+            return false
+        }
+        if lhs.satsPerVbyte != rhs.satsPerVbyte {
+            return false
+        }
+        if lhs.backend != rhs.backend {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(preferenceType)
+        hasher.combine(speed)
+        hasher.combine(targetConf)
+        hasher.combine(satsPerVbyte)
+        hasher.combine(backend)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainFeePreference: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainFeePreference {
+        return
+            try OnchainFeePreference(
+                preferenceType: FfiConverterTypeOnchainFeePreferenceType.read(from: &buf),
+                speed: FfiConverterOptionTypeOnchainFeeSpeed.read(from: &buf),
+                targetConf: FfiConverterOptionInt64.read(from: &buf),
+                satsPerVbyte: FfiConverterOptionDouble.read(from: &buf),
+                backend: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: OnchainFeePreference, into buf: inout [UInt8]) {
+        FfiConverterTypeOnchainFeePreferenceType.write(value.preferenceType, into: &buf)
+        FfiConverterOptionTypeOnchainFeeSpeed.write(value.speed, into: &buf)
+        FfiConverterOptionInt64.write(value.targetConf, into: &buf)
+        FfiConverterOptionDouble.write(value.satsPerVbyte, into: &buf)
+        FfiConverterOptionString.write(value.backend, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePreference_lift(_ buf: RustBuffer) throws -> OnchainFeePreference {
+    return try FfiConverterTypeOnchainFeePreference.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePreference_lower(_ value: OnchainFeePreference) -> RustBuffer {
+    return FfiConverterTypeOnchainFeePreference.lower(value)
+}
+
+
+public struct OnchainTransaction {
+    public var id: String?
+    public var address: String
+    public var amountSats: Int64
+    public var feeSats: Int64?
+    public var totalAmountSats: Int64?
+    public var recipientAmountSats: Int64?
+    public var feePayer: OnchainFeePayer
+    public var fee: OnchainFeePreference
+    public var expiresAt: Int64?
+    public var estimatedDeliverySeconds: Int64?
+    public var raw: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String? = nil, address: String, amountSats: Int64, feeSats: Int64? = nil, totalAmountSats: Int64? = nil, recipientAmountSats: Int64? = nil, feePayer: OnchainFeePayer, fee: OnchainFeePreference, expiresAt: Int64? = nil, estimatedDeliverySeconds: Int64? = nil, raw: String? = nil) {
+        self.id = id
+        self.address = address
+        self.amountSats = amountSats
+        self.feeSats = feeSats
+        self.totalAmountSats = totalAmountSats
+        self.recipientAmountSats = recipientAmountSats
+        self.feePayer = feePayer
+        self.fee = fee
+        self.expiresAt = expiresAt
+        self.estimatedDeliverySeconds = estimatedDeliverySeconds
+        self.raw = raw
+    }
+}
+
+#if compiler(>=6)
+extension OnchainTransaction: Sendable {}
+#endif
+
+
+extension OnchainTransaction: Equatable, Hashable {
+    public static func ==(lhs: OnchainTransaction, rhs: OnchainTransaction) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.address != rhs.address {
+            return false
+        }
+        if lhs.amountSats != rhs.amountSats {
+            return false
+        }
+        if lhs.feeSats != rhs.feeSats {
+            return false
+        }
+        if lhs.totalAmountSats != rhs.totalAmountSats {
+            return false
+        }
+        if lhs.recipientAmountSats != rhs.recipientAmountSats {
+            return false
+        }
+        if lhs.feePayer != rhs.feePayer {
+            return false
+        }
+        if lhs.fee != rhs.fee {
+            return false
+        }
+        if lhs.expiresAt != rhs.expiresAt {
+            return false
+        }
+        if lhs.estimatedDeliverySeconds != rhs.estimatedDeliverySeconds {
+            return false
+        }
+        if lhs.raw != rhs.raw {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(address)
+        hasher.combine(amountSats)
+        hasher.combine(feeSats)
+        hasher.combine(totalAmountSats)
+        hasher.combine(recipientAmountSats)
+        hasher.combine(feePayer)
+        hasher.combine(fee)
+        hasher.combine(expiresAt)
+        hasher.combine(estimatedDeliverySeconds)
+        hasher.combine(raw)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainTransaction: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainTransaction {
+        return
+            try OnchainTransaction(
+                id: FfiConverterOptionString.read(from: &buf),
+                address: FfiConverterString.read(from: &buf),
+                amountSats: FfiConverterInt64.read(from: &buf),
+                feeSats: FfiConverterOptionInt64.read(from: &buf),
+                totalAmountSats: FfiConverterOptionInt64.read(from: &buf),
+                recipientAmountSats: FfiConverterOptionInt64.read(from: &buf),
+                feePayer: FfiConverterTypeOnchainFeePayer.read(from: &buf),
+                fee: FfiConverterTypeOnchainFeePreference.read(from: &buf),
+                expiresAt: FfiConverterOptionInt64.read(from: &buf),
+                estimatedDeliverySeconds: FfiConverterOptionInt64.read(from: &buf),
+                raw: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: OnchainTransaction, into buf: inout [UInt8]) {
+        FfiConverterOptionString.write(value.id, into: &buf)
+        FfiConverterString.write(value.address, into: &buf)
+        FfiConverterInt64.write(value.amountSats, into: &buf)
+        FfiConverterOptionInt64.write(value.feeSats, into: &buf)
+        FfiConverterOptionInt64.write(value.totalAmountSats, into: &buf)
+        FfiConverterOptionInt64.write(value.recipientAmountSats, into: &buf)
+        FfiConverterTypeOnchainFeePayer.write(value.feePayer, into: &buf)
+        FfiConverterTypeOnchainFeePreference.write(value.fee, into: &buf)
+        FfiConverterOptionInt64.write(value.expiresAt, into: &buf)
+        FfiConverterOptionInt64.write(value.estimatedDeliverySeconds, into: &buf)
+        FfiConverterOptionString.write(value.raw, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainTransaction_lift(_ buf: RustBuffer) throws -> OnchainTransaction {
+    return try FfiConverterTypeOnchainTransaction.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainTransaction_lower(_ value: OnchainTransaction) -> RustBuffer {
+    return FfiConverterTypeOnchainTransaction.lower(value)
 }
 
 
@@ -6306,8 +9459,8 @@ public struct FfiConverterTypeOpenChannelRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OpenChannelRequest {
         return
             try OpenChannelRequest(
-                pubkey: FfiConverterString.read(from: &buf), 
-                amountMsats: FfiConverterInt64.read(from: &buf), 
+                pubkey: FfiConverterString.read(from: &buf),
+                amountMsats: FfiConverterInt64.read(from: &buf),
                 public: FfiConverterBool.read(from: &buf)
         )
     }
@@ -6488,15 +9641,15 @@ public struct FfiConverterTypePayInvoiceParams: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayInvoiceParams {
         return
             try PayInvoiceParams(
-                invoice: FfiConverterString.read(from: &buf), 
-                feeLimitMsat: FfiConverterOptionInt64.read(from: &buf), 
-                feeLimitPercentage: FfiConverterOptionDouble.read(from: &buf), 
-                timeoutSeconds: FfiConverterOptionInt64.read(from: &buf), 
-                amountMsats: FfiConverterOptionInt64.read(from: &buf), 
-                maxParts: FfiConverterOptionInt64.read(from: &buf), 
-                firstHopPubkey: FfiConverterOptionString.read(from: &buf), 
-                lastHopPubkey: FfiConverterOptionString.read(from: &buf), 
-                allowSelfPayment: FfiConverterOptionBool.read(from: &buf), 
+                invoice: FfiConverterString.read(from: &buf),
+                feeLimitMsat: FfiConverterOptionInt64.read(from: &buf),
+                feeLimitPercentage: FfiConverterOptionDouble.read(from: &buf),
+                timeoutSeconds: FfiConverterOptionInt64.read(from: &buf),
+                amountMsats: FfiConverterOptionInt64.read(from: &buf),
+                maxParts: FfiConverterOptionInt64.read(from: &buf),
+                firstHopPubkey: FfiConverterOptionString.read(from: &buf),
+                lastHopPubkey: FfiConverterOptionString.read(from: &buf),
+                allowSelfPayment: FfiConverterOptionBool.read(from: &buf),
                 isAmp: FfiConverterOptionBool.read(from: &buf)
         )
     }
@@ -6580,8 +9733,8 @@ public struct FfiConverterTypePayInvoiceResponse: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayInvoiceResponse {
         return
             try PayInvoiceResponse(
-                paymentHash: FfiConverterString.read(from: &buf), 
-                preimage: FfiConverterString.read(from: &buf), 
+                paymentHash: FfiConverterString.read(from: &buf),
+                preimage: FfiConverterString.read(from: &buf),
                 feeMsats: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -6671,6 +9824,210 @@ public func FfiConverterTypePayKeysendResponse_lower(_ value: PayKeysendResponse
 }
 
 
+public struct PayOnchainOptions {
+    public var feeGuardrail: OnchainFeeGuardrail?
+    public var dangerouslyDisableFeeGuardrail: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(feeGuardrail: OnchainFeeGuardrail? = nil, dangerouslyDisableFeeGuardrail: Bool = false) {
+        self.feeGuardrail = feeGuardrail
+        self.dangerouslyDisableFeeGuardrail = dangerouslyDisableFeeGuardrail
+    }
+}
+
+#if compiler(>=6)
+extension PayOnchainOptions: Sendable {}
+#endif
+
+
+extension PayOnchainOptions: Equatable, Hashable {
+    public static func ==(lhs: PayOnchainOptions, rhs: PayOnchainOptions) -> Bool {
+        if lhs.feeGuardrail != rhs.feeGuardrail {
+            return false
+        }
+        if lhs.dangerouslyDisableFeeGuardrail != rhs.dangerouslyDisableFeeGuardrail {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(feeGuardrail)
+        hasher.combine(dangerouslyDisableFeeGuardrail)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayOnchainOptions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayOnchainOptions {
+        return
+            try PayOnchainOptions(
+                feeGuardrail: FfiConverterOptionTypeOnchainFeeGuardrail.read(from: &buf),
+                dangerouslyDisableFeeGuardrail: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PayOnchainOptions, into buf: inout [UInt8]) {
+        FfiConverterOptionTypeOnchainFeeGuardrail.write(value.feeGuardrail, into: &buf)
+        FfiConverterBool.write(value.dangerouslyDisableFeeGuardrail, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayOnchainOptions_lift(_ buf: RustBuffer) throws -> PayOnchainOptions {
+    return try FfiConverterTypePayOnchainOptions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayOnchainOptions_lower(_ value: PayOnchainOptions) -> RustBuffer {
+    return FfiConverterTypePayOnchainOptions.lower(value)
+}
+
+
+public struct PayOnchainResponse {
+    public var paymentId: String?
+    public var txid: String?
+    public var state: String
+    public var address: String
+    public var amountSats: Int64
+    public var feeSats: Int64?
+    public var totalAmountSats: Int64?
+    public var recipientAmountSats: Int64?
+    public var createdAt: Int64?
+    public var raw: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(paymentId: String? = nil, txid: String? = nil, state: String, address: String, amountSats: Int64, feeSats: Int64? = nil, totalAmountSats: Int64? = nil, recipientAmountSats: Int64? = nil, createdAt: Int64? = nil, raw: String? = nil) {
+        self.paymentId = paymentId
+        self.txid = txid
+        self.state = state
+        self.address = address
+        self.amountSats = amountSats
+        self.feeSats = feeSats
+        self.totalAmountSats = totalAmountSats
+        self.recipientAmountSats = recipientAmountSats
+        self.createdAt = createdAt
+        self.raw = raw
+    }
+}
+
+#if compiler(>=6)
+extension PayOnchainResponse: Sendable {}
+#endif
+
+
+extension PayOnchainResponse: Equatable, Hashable {
+    public static func ==(lhs: PayOnchainResponse, rhs: PayOnchainResponse) -> Bool {
+        if lhs.paymentId != rhs.paymentId {
+            return false
+        }
+        if lhs.txid != rhs.txid {
+            return false
+        }
+        if lhs.state != rhs.state {
+            return false
+        }
+        if lhs.address != rhs.address {
+            return false
+        }
+        if lhs.amountSats != rhs.amountSats {
+            return false
+        }
+        if lhs.feeSats != rhs.feeSats {
+            return false
+        }
+        if lhs.totalAmountSats != rhs.totalAmountSats {
+            return false
+        }
+        if lhs.recipientAmountSats != rhs.recipientAmountSats {
+            return false
+        }
+        if lhs.createdAt != rhs.createdAt {
+            return false
+        }
+        if lhs.raw != rhs.raw {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(paymentId)
+        hasher.combine(txid)
+        hasher.combine(state)
+        hasher.combine(address)
+        hasher.combine(amountSats)
+        hasher.combine(feeSats)
+        hasher.combine(totalAmountSats)
+        hasher.combine(recipientAmountSats)
+        hasher.combine(createdAt)
+        hasher.combine(raw)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePayOnchainResponse: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PayOnchainResponse {
+        return
+            try PayOnchainResponse(
+                paymentId: FfiConverterOptionString.read(from: &buf),
+                txid: FfiConverterOptionString.read(from: &buf),
+                state: FfiConverterString.read(from: &buf),
+                address: FfiConverterString.read(from: &buf),
+                amountSats: FfiConverterInt64.read(from: &buf),
+                feeSats: FfiConverterOptionInt64.read(from: &buf),
+                totalAmountSats: FfiConverterOptionInt64.read(from: &buf),
+                recipientAmountSats: FfiConverterOptionInt64.read(from: &buf),
+                createdAt: FfiConverterOptionInt64.read(from: &buf),
+                raw: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PayOnchainResponse, into buf: inout [UInt8]) {
+        FfiConverterOptionString.write(value.paymentId, into: &buf)
+        FfiConverterOptionString.write(value.txid, into: &buf)
+        FfiConverterString.write(value.state, into: &buf)
+        FfiConverterString.write(value.address, into: &buf)
+        FfiConverterInt64.write(value.amountSats, into: &buf)
+        FfiConverterOptionInt64.write(value.feeSats, into: &buf)
+        FfiConverterOptionInt64.write(value.totalAmountSats, into: &buf)
+        FfiConverterOptionInt64.write(value.recipientAmountSats, into: &buf)
+        FfiConverterOptionInt64.write(value.createdAt, into: &buf)
+        FfiConverterOptionString.write(value.raw, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayOnchainResponse_lift(_ buf: RustBuffer) throws -> PayOnchainResponse {
+    return try FfiConverterTypePayOnchainResponse.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePayOnchainResponse_lower(_ value: PayOnchainResponse) -> RustBuffer {
+    return FfiConverterTypePayOnchainResponse.lower(value)
+}
+
+
 public struct PaymentFailedEventProperties {
     public var transaction: Transaction
     public var reason: String
@@ -6714,7 +10071,7 @@ public struct FfiConverterTypePaymentFailedEventProperties: FfiConverterRustBuff
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PaymentFailedEventProperties {
         return
             try PaymentFailedEventProperties(
-                transaction: FfiConverterTypeTransaction.read(from: &buf), 
+                transaction: FfiConverterTypeTransaction.read(from: &buf),
                 reason: FfiConverterString.read(from: &buf)
         )
     }
@@ -6796,9 +10153,9 @@ public struct FfiConverterTypePeerDetails: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PeerDetails {
         return
             try PeerDetails(
-                nodeId: FfiConverterString.read(from: &buf), 
-                address: FfiConverterString.read(from: &buf), 
-                isPersisted: FfiConverterBool.read(from: &buf), 
+                nodeId: FfiConverterString.read(from: &buf),
+                address: FfiConverterString.read(from: &buf),
+                isPersisted: FfiConverterBool.read(from: &buf),
                 isConnected: FfiConverterBool.read(from: &buf)
         )
     }
@@ -6888,10 +10245,10 @@ public struct FfiConverterTypePendingBalanceDetails: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PendingBalanceDetails {
         return
             try PendingBalanceDetails(
-                channelId: FfiConverterString.read(from: &buf), 
-                nodeId: FfiConverterString.read(from: &buf), 
-                amountMsats: FfiConverterInt64.read(from: &buf), 
-                fundingTxId: FfiConverterString.read(from: &buf), 
+                channelId: FfiConverterString.read(from: &buf),
+                nodeId: FfiConverterString.read(from: &buf),
+                amountMsats: FfiConverterInt64.read(from: &buf),
+                fundingTxId: FfiConverterString.read(from: &buf),
                 fundingTxVout: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -6921,6 +10278,148 @@ public func FfiConverterTypePendingBalanceDetails_lower(_ value: PendingBalanceD
 }
 
 
+public struct Permissions {
+    public var getInfo: Bool
+    public var createInvoice: Bool
+    public var payInvoice: Bool
+    public var createOffer: Bool
+    public var getOffer: Bool
+    public var listOffers: Bool
+    public var payOffer: Bool
+    public var lookupInvoice: Bool
+    public var listTransactions: Bool
+    public var decode: Bool
+    public var onInvoiceEvents: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(getInfo: Bool, createInvoice: Bool, payInvoice: Bool, createOffer: Bool, getOffer: Bool, listOffers: Bool, payOffer: Bool, lookupInvoice: Bool, listTransactions: Bool, decode: Bool, onInvoiceEvents: Bool) {
+        self.getInfo = getInfo
+        self.createInvoice = createInvoice
+        self.payInvoice = payInvoice
+        self.createOffer = createOffer
+        self.getOffer = getOffer
+        self.listOffers = listOffers
+        self.payOffer = payOffer
+        self.lookupInvoice = lookupInvoice
+        self.listTransactions = listTransactions
+        self.decode = decode
+        self.onInvoiceEvents = onInvoiceEvents
+    }
+}
+
+#if compiler(>=6)
+extension Permissions: Sendable {}
+#endif
+
+
+extension Permissions: Equatable, Hashable {
+    public static func ==(lhs: Permissions, rhs: Permissions) -> Bool {
+        if lhs.getInfo != rhs.getInfo {
+            return false
+        }
+        if lhs.createInvoice != rhs.createInvoice {
+            return false
+        }
+        if lhs.payInvoice != rhs.payInvoice {
+            return false
+        }
+        if lhs.createOffer != rhs.createOffer {
+            return false
+        }
+        if lhs.getOffer != rhs.getOffer {
+            return false
+        }
+        if lhs.listOffers != rhs.listOffers {
+            return false
+        }
+        if lhs.payOffer != rhs.payOffer {
+            return false
+        }
+        if lhs.lookupInvoice != rhs.lookupInvoice {
+            return false
+        }
+        if lhs.listTransactions != rhs.listTransactions {
+            return false
+        }
+        if lhs.decode != rhs.decode {
+            return false
+        }
+        if lhs.onInvoiceEvents != rhs.onInvoiceEvents {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(getInfo)
+        hasher.combine(createInvoice)
+        hasher.combine(payInvoice)
+        hasher.combine(createOffer)
+        hasher.combine(getOffer)
+        hasher.combine(listOffers)
+        hasher.combine(payOffer)
+        hasher.combine(lookupInvoice)
+        hasher.combine(listTransactions)
+        hasher.combine(decode)
+        hasher.combine(onInvoiceEvents)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePermissions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Permissions {
+        return
+            try Permissions(
+                getInfo: FfiConverterBool.read(from: &buf),
+                createInvoice: FfiConverterBool.read(from: &buf),
+                payInvoice: FfiConverterBool.read(from: &buf),
+                createOffer: FfiConverterBool.read(from: &buf),
+                getOffer: FfiConverterBool.read(from: &buf),
+                listOffers: FfiConverterBool.read(from: &buf),
+                payOffer: FfiConverterBool.read(from: &buf),
+                lookupInvoice: FfiConverterBool.read(from: &buf),
+                listTransactions: FfiConverterBool.read(from: &buf),
+                decode: FfiConverterBool.read(from: &buf),
+                onInvoiceEvents: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Permissions, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.getInfo, into: &buf)
+        FfiConverterBool.write(value.createInvoice, into: &buf)
+        FfiConverterBool.write(value.payInvoice, into: &buf)
+        FfiConverterBool.write(value.createOffer, into: &buf)
+        FfiConverterBool.write(value.getOffer, into: &buf)
+        FfiConverterBool.write(value.listOffers, into: &buf)
+        FfiConverterBool.write(value.payOffer, into: &buf)
+        FfiConverterBool.write(value.lookupInvoice, into: &buf)
+        FfiConverterBool.write(value.listTransactions, into: &buf)
+        FfiConverterBool.write(value.decode, into: &buf)
+        FfiConverterBool.write(value.onInvoiceEvents, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePermissions_lift(_ buf: RustBuffer) throws -> Permissions {
+    return try FfiConverterTypePermissions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePermissions_lower(_ value: Permissions) -> RustBuffer {
+    return FfiConverterTypePermissions.lower(value)
+}
+
+
 public struct PhoenixdConfig {
     public var url: String
     public var password: String
@@ -6930,7 +10429,7 @@ public struct PhoenixdConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(url: String, password: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(url: String, password: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.url = url
         self.password = password
         self.socks5Proxy = socks5Proxy
@@ -6982,10 +10481,10 @@ public struct FfiConverterTypePhoenixdConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PhoenixdConfig {
         return
             try PhoenixdConfig(
-                url: FfiConverterString.read(from: &buf), 
-                password: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                url: FfiConverterString.read(from: &buf),
+                password: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -7012,6 +10511,108 @@ public func FfiConverterTypePhoenixdConfig_lift(_ buf: RustBuffer) throws -> Pho
 #endif
 public func FfiConverterTypePhoenixdConfig_lower(_ value: PhoenixdConfig) -> RustBuffer {
     return FfiConverterTypePhoenixdConfig.lower(value)
+}
+
+
+public struct PrepareOnchainTransactionParams {
+    public var address: String
+    public var amountSats: Int64
+    public var fee: OnchainFeePreference?
+    public var feePayer: OnchainFeePayer?
+    public var description: String?
+    public var idempotencyKey: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(address: String, amountSats: Int64, fee: OnchainFeePreference? = nil, feePayer: OnchainFeePayer? = nil, description: String? = nil, idempotencyKey: String? = nil) {
+        self.address = address
+        self.amountSats = amountSats
+        self.fee = fee
+        self.feePayer = feePayer
+        self.description = description
+        self.idempotencyKey = idempotencyKey
+    }
+}
+
+#if compiler(>=6)
+extension PrepareOnchainTransactionParams: Sendable {}
+#endif
+
+
+extension PrepareOnchainTransactionParams: Equatable, Hashable {
+    public static func ==(lhs: PrepareOnchainTransactionParams, rhs: PrepareOnchainTransactionParams) -> Bool {
+        if lhs.address != rhs.address {
+            return false
+        }
+        if lhs.amountSats != rhs.amountSats {
+            return false
+        }
+        if lhs.fee != rhs.fee {
+            return false
+        }
+        if lhs.feePayer != rhs.feePayer {
+            return false
+        }
+        if lhs.description != rhs.description {
+            return false
+        }
+        if lhs.idempotencyKey != rhs.idempotencyKey {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(address)
+        hasher.combine(amountSats)
+        hasher.combine(fee)
+        hasher.combine(feePayer)
+        hasher.combine(description)
+        hasher.combine(idempotencyKey)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePrepareOnchainTransactionParams: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PrepareOnchainTransactionParams {
+        return
+            try PrepareOnchainTransactionParams(
+                address: FfiConverterString.read(from: &buf),
+                amountSats: FfiConverterInt64.read(from: &buf),
+                fee: FfiConverterOptionTypeOnchainFeePreference.read(from: &buf),
+                feePayer: FfiConverterOptionTypeOnchainFeePayer.read(from: &buf),
+                description: FfiConverterOptionString.read(from: &buf),
+                idempotencyKey: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PrepareOnchainTransactionParams, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.address, into: &buf)
+        FfiConverterInt64.write(value.amountSats, into: &buf)
+        FfiConverterOptionTypeOnchainFeePreference.write(value.fee, into: &buf)
+        FfiConverterOptionTypeOnchainFeePayer.write(value.feePayer, into: &buf)
+        FfiConverterOptionString.write(value.description, into: &buf)
+        FfiConverterOptionString.write(value.idempotencyKey, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePrepareOnchainTransactionParams_lift(_ buf: RustBuffer) throws -> PrepareOnchainTransactionParams {
+    return try FfiConverterTypePrepareOnchainTransactionParams.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePrepareOnchainTransactionParams_lower(_ value: PrepareOnchainTransactionParams) -> RustBuffer {
+    return FfiConverterTypePrepareOnchainTransactionParams.lower(value)
 }
 
 
@@ -7042,16 +10643,16 @@ public struct SparkConfig {
     public init(
         /**
          * 12 or 24 word mnemonic phrase
-         */mnemonic: String, 
+         */mnemonic: String,
         /**
          * Optional passphrase for the mnemonic
-         */passphrase: String? = nil, 
+         */passphrase: String? = nil,
         /**
          * Breez API key (required for mainnet)
-         */apiKey: String? = nil, 
+         */apiKey: String? = nil,
         /**
          * Storage directory path for wallet data
-         */storageDir: String, 
+         */storageDir: String,
         /**
          * Network: "mainnet" or "regtest"
          */network: String? = "mainnet") {
@@ -7106,10 +10707,10 @@ public struct FfiConverterTypeSparkConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SparkConfig {
         return
             try SparkConfig(
-                mnemonic: FfiConverterString.read(from: &buf), 
-                passphrase: FfiConverterOptionString.read(from: &buf), 
-                apiKey: FfiConverterOptionString.read(from: &buf), 
-                storageDir: FfiConverterString.read(from: &buf), 
+                mnemonic: FfiConverterString.read(from: &buf),
+                passphrase: FfiConverterOptionString.read(from: &buf),
+                apiKey: FfiConverterOptionString.read(from: &buf),
+                storageDir: FfiConverterString.read(from: &buf),
                 network: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -7148,7 +10749,7 @@ public struct SpeedConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(baseUrl: String? = "https://api.tryspeed.com", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(baseUrl: String? = "https://api.tryspeed.com", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.baseUrl = baseUrl
         self.apiKey = apiKey
         self.socks5Proxy = socks5Proxy
@@ -7200,10 +10801,10 @@ public struct FfiConverterTypeSpeedConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SpeedConfig {
         return
             try SpeedConfig(
-                baseUrl: FfiConverterOptionString.read(from: &buf), 
-                apiKey: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                baseUrl: FfiConverterOptionString.read(from: &buf),
+                apiKey: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -7242,7 +10843,7 @@ public struct StrikeConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(baseUrl: String? = "https://api.strike.me/v1", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = true, httpTimeout: Int64? = Int64(120)) {
+    public init(baseUrl: String? = "https://api.strike.me/v1", apiKey: String, socks5Proxy: String? = "", acceptInvalidCerts: Bool? = false, httpTimeout: Int64? = Int64(120)) {
         self.baseUrl = baseUrl
         self.apiKey = apiKey
         self.socks5Proxy = socks5Proxy
@@ -7294,10 +10895,10 @@ public struct FfiConverterTypeStrikeConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> StrikeConfig {
         return
             try StrikeConfig(
-                baseUrl: FfiConverterOptionString.read(from: &buf), 
-                apiKey: FfiConverterString.read(from: &buf), 
-                socks5Proxy: FfiConverterOptionString.read(from: &buf), 
-                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf), 
+                baseUrl: FfiConverterOptionString.read(from: &buf),
+                apiKey: FfiConverterString.read(from: &buf),
+                socks5Proxy: FfiConverterOptionString.read(from: &buf),
+                acceptInvalidCerts: FfiConverterOptionBool.read(from: &buf),
                 httpTimeout: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -7370,7 +10971,7 @@ public struct FfiConverterTypeTLVRecord: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TlvRecord {
         return
             try TlvRecord(
-                type: FfiConverterInt64.read(from: &buf), 
+                type: FfiConverterInt64.read(from: &buf),
                 value: FfiConverterString.read(from: &buf)
         )
     }
@@ -7411,10 +11012,13 @@ public struct Transaction {
     public var settledAt: Int64
     public var payerNote: String?
     public var externalId: String?
+    public var settlementType: SettlementType?
+    public var settlementState: SettlementState?
+    public var txid: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(type: String, invoice: String, description: String, descriptionHash: String, preimage: String, paymentHash: String, amountMsats: Int64, feesPaid: Int64, createdAt: Int64, expiresAt: Int64, settledAt: Int64, payerNote: String?, externalId: String?) {
+    public init(type: String, invoice: String, description: String, descriptionHash: String, preimage: String, paymentHash: String, amountMsats: Int64, feesPaid: Int64, createdAt: Int64, expiresAt: Int64, settledAt: Int64, payerNote: String?, externalId: String?, settlementType: SettlementType? = nil, settlementState: SettlementState? = nil, txid: String? = nil) {
         self.type = type
         self.invoice = invoice
         self.description = description
@@ -7428,6 +11032,9 @@ public struct Transaction {
         self.settledAt = settledAt
         self.payerNote = payerNote
         self.externalId = externalId
+        self.settlementType = settlementType
+        self.settlementState = settlementState
+        self.txid = txid
     }
 }
 
@@ -7477,6 +11084,15 @@ extension Transaction: Equatable, Hashable {
         if lhs.externalId != rhs.externalId {
             return false
         }
+        if lhs.settlementType != rhs.settlementType {
+            return false
+        }
+        if lhs.settlementState != rhs.settlementState {
+            return false
+        }
+        if lhs.txid != rhs.txid {
+            return false
+        }
         return true
     }
 
@@ -7494,6 +11110,9 @@ extension Transaction: Equatable, Hashable {
         hasher.combine(settledAt)
         hasher.combine(payerNote)
         hasher.combine(externalId)
+        hasher.combine(settlementType)
+        hasher.combine(settlementState)
+        hasher.combine(txid)
     }
 }
 
@@ -7506,19 +11125,22 @@ public struct FfiConverterTypeTransaction: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Transaction {
         return
             try Transaction(
-                type: FfiConverterString.read(from: &buf), 
-                invoice: FfiConverterString.read(from: &buf), 
-                description: FfiConverterString.read(from: &buf), 
-                descriptionHash: FfiConverterString.read(from: &buf), 
-                preimage: FfiConverterString.read(from: &buf), 
-                paymentHash: FfiConverterString.read(from: &buf), 
-                amountMsats: FfiConverterInt64.read(from: &buf), 
-                feesPaid: FfiConverterInt64.read(from: &buf), 
-                createdAt: FfiConverterInt64.read(from: &buf), 
-                expiresAt: FfiConverterInt64.read(from: &buf), 
-                settledAt: FfiConverterInt64.read(from: &buf), 
-                payerNote: FfiConverterOptionString.read(from: &buf), 
-                externalId: FfiConverterOptionString.read(from: &buf)
+                type: FfiConverterString.read(from: &buf),
+                invoice: FfiConverterString.read(from: &buf),
+                description: FfiConverterString.read(from: &buf),
+                descriptionHash: FfiConverterString.read(from: &buf),
+                preimage: FfiConverterString.read(from: &buf),
+                paymentHash: FfiConverterString.read(from: &buf),
+                amountMsats: FfiConverterInt64.read(from: &buf),
+                feesPaid: FfiConverterInt64.read(from: &buf),
+                createdAt: FfiConverterInt64.read(from: &buf),
+                expiresAt: FfiConverterInt64.read(from: &buf),
+                settledAt: FfiConverterInt64.read(from: &buf),
+                payerNote: FfiConverterOptionString.read(from: &buf),
+                externalId: FfiConverterOptionString.read(from: &buf),
+                settlementType: FfiConverterOptionTypeSettlementType.read(from: &buf),
+                settlementState: FfiConverterOptionTypeSettlementState.read(from: &buf),
+                txid: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -7536,6 +11158,9 @@ public struct FfiConverterTypeTransaction: FfiConverterRustBuffer {
         FfiConverterInt64.write(value.settledAt, into: &buf)
         FfiConverterOptionString.write(value.payerNote, into: &buf)
         FfiConverterOptionString.write(value.externalId, into: &buf)
+        FfiConverterOptionTypeSettlementType.write(value.settlementType, into: &buf)
+        FfiConverterOptionTypeSettlementState.write(value.settlementState, into: &buf)
+        FfiConverterOptionString.write(value.txid, into: &buf)
     }
 }
 
@@ -7610,9 +11235,9 @@ public struct FfiConverterTypeUpdateChannelRequest: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UpdateChannelRequest {
         return
             try UpdateChannelRequest(
-                channelId: FfiConverterString.read(from: &buf), 
-                nodeId: FfiConverterString.read(from: &buf), 
-                forwardingFeeBaseMsat: FfiConverterInt64.read(from: &buf), 
+                channelId: FfiConverterString.read(from: &buf),
+                nodeId: FfiConverterString.read(from: &buf),
+                forwardingFeeBaseMsat: FfiConverterInt64.read(from: &buf),
                 maxDustHtlcExposureFromFeeRateMultiplier: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -7643,13 +11268,21 @@ public func FfiConverterTypeUpdateChannelRequest_lower(_ value: UpdateChannelReq
 
 public enum ApiError: Swift.Error {
 
-    
-    
+
+
     case Http(reason: String
     )
     case Api(reason: String
     )
     case Json(reason: String
+    )
+    case NetworkError(String
+    )
+    case InvalidInput(String
+    )
+    case LnurlError(String
+    )
+    case Nwc(code: String, message: String
     )
 }
 
@@ -7664,9 +11297,9 @@ public struct FfiConverterTypeApiError: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
 
-        
 
-        
+
+
         case 1: return .Http(
             reason: try FfiConverterString.read(from: &buf)
             )
@@ -7676,6 +11309,19 @@ public struct FfiConverterTypeApiError: FfiConverterRustBuffer {
         case 3: return .Json(
             reason: try FfiConverterString.read(from: &buf)
             )
+        case 4: return .NetworkError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 5: return .InvalidInput(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 6: return .LnurlError(
+            try FfiConverterString.read(from: &buf)
+            )
+        case 7: return .Nwc(
+            code: try FfiConverterString.read(from: &buf),
+            message: try FfiConverterString.read(from: &buf)
+            )
 
          default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -7684,24 +11330,45 @@ public struct FfiConverterTypeApiError: FfiConverterRustBuffer {
     public static func write(_ value: ApiError, into buf: inout [UInt8]) {
         switch value {
 
-        
 
-        
-        
+
+
+
         case let .Http(reason):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(reason, into: &buf)
-            
-        
+
+
         case let .Api(reason):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(reason, into: &buf)
-            
-        
+
+
         case let .Json(reason):
             writeInt(&buf, Int32(3))
             FfiConverterString.write(reason, into: &buf)
-            
+
+
+        case let .NetworkError(v1):
+            writeInt(&buf, Int32(4))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .InvalidInput(v1):
+            writeInt(&buf, Int32(5))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .LnurlError(v1):
+            writeInt(&buf, Int32(6))
+            FfiConverterString.write(v1, into: &buf)
+
+
+        case let .Nwc(code,message):
+            writeInt(&buf, Int32(7))
+            FfiConverterString.write(code, into: &buf)
+            FfiConverterString.write(message, into: &buf)
+
         }
     }
 }
@@ -7739,8 +11406,379 @@ extension ApiError: Foundation.LocalizedError {
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
+public enum GaloyInvoiceOperation {
+
+    case btcSats
+    case usdCents
+    case unsupported
+}
+
+
+#if compiler(>=6)
+extension GaloyInvoiceOperation: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyInvoiceOperation: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyInvoiceOperation
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyInvoiceOperation {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .btcSats
+
+        case 2: return .usdCents
+
+        case 3: return .unsupported
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GaloyInvoiceOperation, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .btcSats:
+            writeInt(&buf, Int32(1))
+
+
+        case .usdCents:
+            writeInt(&buf, Int32(2))
+
+
+        case .unsupported:
+            writeInt(&buf, Int32(3))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyInvoiceOperation_lift(_ buf: RustBuffer) throws -> GaloyInvoiceOperation {
+    return try FfiConverterTypeGaloyInvoiceOperation.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyInvoiceOperation_lower(_ value: GaloyInvoiceOperation) -> RustBuffer {
+    return FfiConverterTypeGaloyInvoiceOperation.lower(value)
+}
+
+
+extension GaloyInvoiceOperation: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum GaloyPaymentResponse {
+
+    case transactionWithPreimage
+    case statusOnly
+}
+
+
+#if compiler(>=6)
+extension GaloyPaymentResponse: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPaymentResponse: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyPaymentResponse
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPaymentResponse {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .transactionWithPreimage
+
+        case 2: return .statusOnly
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GaloyPaymentResponse, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .transactionWithPreimage:
+            writeInt(&buf, Int32(1))
+
+
+        case .statusOnly:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentResponse_lift(_ buf: RustBuffer) throws -> GaloyPaymentResponse {
+    return try FfiConverterTypeGaloyPaymentResponse.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentResponse_lower(_ value: GaloyPaymentResponse) -> RustBuffer {
+    return FfiConverterTypeGaloyPaymentResponse.lower(value)
+}
+
+
+extension GaloyPaymentResponse: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum GaloyPaymentState {
+
+    case settled
+    case pending
+    case accepted
+}
+
+
+#if compiler(>=6)
+extension GaloyPaymentState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPaymentState: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyPaymentState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPaymentState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .settled
+
+        case 2: return .pending
+
+        case 3: return .accepted
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GaloyPaymentState, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .settled:
+            writeInt(&buf, Int32(1))
+
+
+        case .pending:
+            writeInt(&buf, Int32(2))
+
+
+        case .accepted:
+            writeInt(&buf, Int32(3))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentState_lift(_ buf: RustBuffer) throws -> GaloyPaymentState {
+    return try FfiConverterTypeGaloyPaymentState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPaymentState_lower(_ value: GaloyPaymentState) -> RustBuffer {
+    return FfiConverterTypeGaloyPaymentState.lower(value)
+}
+
+
+extension GaloyPaymentState: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum GaloyPermissionsMode {
+
+    case jwtIntrospection
+    case configured
+}
+
+
+#if compiler(>=6)
+extension GaloyPermissionsMode: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyPermissionsMode: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyPermissionsMode
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyPermissionsMode {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .jwtIntrospection
+
+        case 2: return .configured
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GaloyPermissionsMode, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .jwtIntrospection:
+            writeInt(&buf, Int32(1))
+
+
+        case .configured:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPermissionsMode_lift(_ buf: RustBuffer) throws -> GaloyPermissionsMode {
+    return try FfiConverterTypeGaloyPermissionsMode.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyPermissionsMode_lower(_ value: GaloyPermissionsMode) -> RustBuffer {
+    return FfiConverterTypeGaloyPermissionsMode.lower(value)
+}
+
+
+extension GaloyPermissionsMode: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum GaloyWalletConfig {
+
+    case explicit(id: String, currency: String
+    )
+    case currency(currency: String
+    )
+}
+
+
+#if compiler(>=6)
+extension GaloyWalletConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeGaloyWalletConfig: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyWalletConfig
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GaloyWalletConfig {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .explicit(id: try FfiConverterString.read(from: &buf), currency: try FfiConverterString.read(from: &buf)
+        )
+
+        case 2: return .currency(currency: try FfiConverterString.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GaloyWalletConfig, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case let .explicit(id,currency):
+            writeInt(&buf, Int32(1))
+            FfiConverterString.write(id, into: &buf)
+            FfiConverterString.write(currency, into: &buf)
+
+
+        case let .currency(currency):
+            writeInt(&buf, Int32(2))
+            FfiConverterString.write(currency, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyWalletConfig_lift(_ buf: RustBuffer) throws -> GaloyWalletConfig {
+    return try FfiConverterTypeGaloyWalletConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeGaloyWalletConfig_lower(_ value: GaloyWalletConfig) -> RustBuffer {
+    return FfiConverterTypeGaloyWalletConfig.lower(value)
+}
+
+
+extension GaloyWalletConfig: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
 public enum InvoiceType {
-    
+
     case bolt11
     case bolt12
 }
@@ -7759,26 +11797,26 @@ public struct FfiConverterTypeInvoiceType: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> InvoiceType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
+
         case 1: return .bolt11
-        
+
         case 2: return .bolt12
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: InvoiceType, into buf: inout [UInt8]) {
         switch value {
-        
-        
+
+
         case .bolt11:
             writeInt(&buf, Int32(1))
-        
-        
+
+
         case .bolt12:
             writeInt(&buf, Int32(2))
-        
+
         }
     }
 }
@@ -7800,6 +11838,419 @@ public func FfiConverterTypeInvoiceType_lower(_ value: InvoiceType) -> RustBuffe
 
 
 extension InvoiceType: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum OnchainFeePayer {
+
+    case sender
+    case recipient
+}
+
+
+#if compiler(>=6)
+extension OnchainFeePayer: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainFeePayer: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeePayer
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainFeePayer {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .sender
+
+        case 2: return .recipient
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: OnchainFeePayer, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .sender:
+            writeInt(&buf, Int32(1))
+
+
+        case .recipient:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePayer_lift(_ buf: RustBuffer) throws -> OnchainFeePayer {
+    return try FfiConverterTypeOnchainFeePayer.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePayer_lower(_ value: OnchainFeePayer) -> RustBuffer {
+    return FfiConverterTypeOnchainFeePayer.lower(value)
+}
+
+
+extension OnchainFeePayer: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum OnchainFeePreferenceType {
+
+    case `default`
+    case speed
+    case targetConf
+    case satsPerVbyte
+    case backend
+}
+
+
+#if compiler(>=6)
+extension OnchainFeePreferenceType: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainFeePreferenceType: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeePreferenceType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainFeePreferenceType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .`default`
+
+        case 2: return .speed
+
+        case 3: return .targetConf
+
+        case 4: return .satsPerVbyte
+
+        case 5: return .backend
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: OnchainFeePreferenceType, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .`default`:
+            writeInt(&buf, Int32(1))
+
+
+        case .speed:
+            writeInt(&buf, Int32(2))
+
+
+        case .targetConf:
+            writeInt(&buf, Int32(3))
+
+
+        case .satsPerVbyte:
+            writeInt(&buf, Int32(4))
+
+
+        case .backend:
+            writeInt(&buf, Int32(5))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePreferenceType_lift(_ buf: RustBuffer) throws -> OnchainFeePreferenceType {
+    return try FfiConverterTypeOnchainFeePreferenceType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeePreferenceType_lower(_ value: OnchainFeePreferenceType) -> RustBuffer {
+    return FfiConverterTypeOnchainFeePreferenceType.lower(value)
+}
+
+
+extension OnchainFeePreferenceType: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum OnchainFeeSpeed {
+
+    case fast
+    case normal
+    case slow
+    case free
+}
+
+
+#if compiler(>=6)
+extension OnchainFeeSpeed: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeOnchainFeeSpeed: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeeSpeed
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OnchainFeeSpeed {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .fast
+
+        case 2: return .normal
+
+        case 3: return .slow
+
+        case 4: return .free
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: OnchainFeeSpeed, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .fast:
+            writeInt(&buf, Int32(1))
+
+
+        case .normal:
+            writeInt(&buf, Int32(2))
+
+
+        case .slow:
+            writeInt(&buf, Int32(3))
+
+
+        case .free:
+            writeInt(&buf, Int32(4))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeeSpeed_lift(_ buf: RustBuffer) throws -> OnchainFeeSpeed {
+    return try FfiConverterTypeOnchainFeeSpeed.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeOnchainFeeSpeed_lower(_ value: OnchainFeeSpeed) -> RustBuffer {
+    return FfiConverterTypeOnchainFeeSpeed.lower(value)
+}
+
+
+extension OnchainFeeSpeed: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum SettlementState {
+
+    case pending
+    case completed
+    case failed
+    case unknown
+}
+
+
+#if compiler(>=6)
+extension SettlementState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSettlementState: FfiConverterRustBuffer {
+    typealias SwiftType = SettlementState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SettlementState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .pending
+
+        case 2: return .completed
+
+        case 3: return .failed
+
+        case 4: return .unknown
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SettlementState, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .pending:
+            writeInt(&buf, Int32(1))
+
+
+        case .completed:
+            writeInt(&buf, Int32(2))
+
+
+        case .failed:
+            writeInt(&buf, Int32(3))
+
+
+        case .unknown:
+            writeInt(&buf, Int32(4))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSettlementState_lift(_ buf: RustBuffer) throws -> SettlementState {
+    return try FfiConverterTypeSettlementState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSettlementState_lower(_ value: SettlementState) -> RustBuffer {
+    return FfiConverterTypeSettlementState.lower(value)
+}
+
+
+extension SettlementState: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum SettlementType {
+
+    case lightning
+    case onchain
+    case intraledger
+    case unknown
+}
+
+
+#if compiler(>=6)
+extension SettlementType: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSettlementType: FfiConverterRustBuffer {
+    typealias SwiftType = SettlementType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SettlementType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .lightning
+
+        case 2: return .onchain
+
+        case 3: return .intraledger
+
+        case 4: return .unknown
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SettlementType, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .lightning:
+            writeInt(&buf, Int32(1))
+
+
+        case .onchain:
+            writeInt(&buf, Int32(2))
+
+
+        case .intraledger:
+            writeInt(&buf, Int32(3))
+
+
+        case .unknown:
+            writeInt(&buf, Int32(4))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSettlementType_lift(_ buf: RustBuffer) throws -> SettlementType {
+    return try FfiConverterTypeSettlementType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSettlementType_lower(_ value: SettlementType) -> RustBuffer {
+    return FfiConverterTypeSettlementType.lower(value)
+}
+
+
+extension SettlementType: Equatable, Hashable {}
 
 
 
@@ -7929,6 +12380,78 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeGaloyPaymentStatusMapping: FfiConverterRustBuffer {
+    typealias SwiftType = GaloyPaymentStatusMapping?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeGaloyPaymentStatusMapping.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeGaloyPaymentStatusMapping.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeOnchainFeeGuardrail: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeeGuardrail?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeOnchainFeeGuardrail.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeOnchainFeeGuardrail.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeOnchainFeePreference: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeePreference?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeOnchainFeePreference.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeOnchainFeePreference.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeTransaction: FfiConverterRustBuffer {
     typealias SwiftType = Transaction?
 
@@ -7971,6 +12494,175 @@ fileprivate struct FfiConverterOptionTypeInvoiceType: FfiConverterRustBuffer {
         case 1: return try FfiConverterTypeInvoiceType.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeOnchainFeePayer: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeePayer?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeOnchainFeePayer.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeOnchainFeePayer.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeOnchainFeeSpeed: FfiConverterRustBuffer {
+    typealias SwiftType = OnchainFeeSpeed?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeOnchainFeeSpeed.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeOnchainFeeSpeed.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeSettlementState: FfiConverterRustBuffer {
+    typealias SwiftType = SettlementState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSettlementState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSettlementState.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeSettlementType: FfiConverterRustBuffer {
+    typealias SwiftType = SettlementType?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSettlementType.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSettlementType.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionSequenceString: FfiConverterRustBuffer {
+    typealias SwiftType = [String]?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterSequenceString.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterSequenceString.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionDictionaryStringString: FfiConverterRustBuffer {
+    typealias SwiftType = [String: String]?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterDictionaryStringString.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterDictionaryStringString.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
+    typealias SwiftType = [String]
+
+    public static func write(_ value: [String], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterString.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [String] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [String]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterString.read(from: &buf))
+        }
+        return seq
     }
 }
 
@@ -8046,6 +12738,32 @@ fileprivate struct FfiConverterSequenceTypeTransaction: FfiConverterRustBuffer {
             seq.append(try FfiConverterTypeTransaction.read(from: &buf))
         }
         return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterDictionaryStringString: FfiConverterRustBuffer {
+    public static func write(_ value: [String: String], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for (key, value) in value {
+            FfiConverterString.write(key, into: &buf)
+            FfiConverterString.write(value, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [String: String] {
+        let len: Int32 = try readInt(&buf)
+        var dict = [String: String]()
+        dict.reserveCapacity(Int(len))
+        for _ in 0..<len {
+            let key = try FfiConverterString.read(from: &buf)
+            let value = try FfiConverterString.read(from: &buf)
+            dict[key] = value
+        }
+        return dict
     }
 }
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
@@ -8197,6 +12915,26 @@ public func createClnNode(config: ClnConfig) -> LightningNode  {
     )
 })
 }
+/**
+ * Create a Flash node backed by the generic Galoy implementation.
+ */
+public func createFlashNode(config: FlashConfig) -> LightningNode  {
+    return try!  FfiConverterTypeLightningNode_lift(try! rustCall() {
+    uniffi_lni_fn_func_create_flash_node(
+        FfiConverterTypeFlashConfig_lower(config),$0
+    )
+})
+}
+/**
+ * Create a configurable Galoy GraphQL node as a polymorphic LightningNode.
+ */
+public func createGaloyNode(config: GaloyConfig) -> LightningNode  {
+    return try!  FfiConverterTypeLightningNode_lift(try! rustCall() {
+    uniffi_lni_fn_func_create_galoy_node(
+        FfiConverterTypeGaloyConfig_lower(config),$0
+    )
+})
+}
 public func createInvoice(config: LndConfig, params: CreateInvoiceParams)async throws  -> Transaction  {
     return
         try  await uniffiRustCallAsync(
@@ -8210,6 +12948,16 @@ public func createInvoice(config: LndConfig, params: CreateInvoiceParams)async t
             liftFunc: FfiConverterTypeTransaction_lift,
             errorHandler: FfiConverterTypeApiError_lift
         )
+}
+/**
+ * Create a Lexe node backed by revocable client credentials.
+ */
+public func createLexeNode(config: LexeConfig)throws  -> LightningNode  {
+    return try  FfiConverterTypeLightningNode_lift(try rustCallWithError(FfiConverterTypeApiError_lift) {
+    uniffi_lni_fn_func_create_lexe_node(
+        FfiConverterTypeLexeConfig_lower(config),$0
+    )
+})
 }
 /**
  * Create an LND node as a polymorphic LightningNode
@@ -8278,11 +13026,25 @@ public func createStrikeNode(config: StrikeConfig) -> LightningNode  {
     )
 })
 }
-public func decode(config: LndConfig, invoiceStr: String)async throws  -> String  {
+public func decode(invoiceStr: String)async throws  -> String  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_lni_fn_func_decode(FfiConverterTypeLndConfig_lower(config),FfiConverterString.lower(invoiceStr)
+                uniffi_lni_fn_func_decode(FfiConverterString.lower(invoiceStr)
+                )
+            },
+            pollFunc: ffi_lni_rust_future_poll_rust_buffer,
+            completeFunc: ffi_lni_rust_future_complete_rust_buffer,
+            freeFunc: ffi_lni_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterString.lift,
+            errorHandler: FfiConverterTypeApiError_lift
+        )
+}
+public func decodeOffer(offer: String)async throws  -> String  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_lni_fn_func_decode_offer(FfiConverterString.lower(offer)
                 )
             },
             pollFunc: ffi_lni_rust_future_poll_rust_buffer,
@@ -8363,7 +13125,7 @@ public func onInvoiceEvents(config: LndConfig, params: OnInvoiceEventParams, cal
             freeFunc: ffi_lni_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
 public func payInvoice(config: LndConfig, params: PayInvoiceParams)async throws  -> PayInvoiceResponse  {
@@ -8392,7 +13154,7 @@ public func sayAfterWithTokio(ms: UInt16, who: String, url: String, socks5Proxy:
             freeFunc: ffi_lni_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
             errorHandler: nil
-            
+
         )
 }
 
@@ -8417,7 +13179,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_func_create_cln_node() != 2566) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_func_create_flash_node() != 54945) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_func_create_galoy_node() != 3857) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_func_create_invoice() != 17504) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_func_create_lexe_node() != 32247) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_func_create_lnd_node() != 38322) {
@@ -8438,7 +13209,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_func_create_strike_node() != 64378) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_func_decode() != 11646) {
+    if (uniffi_lni_checksum_func_decode() != 58600) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_func_decode_offer() != 29103) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_func_generate_mnemonic() != 62024) {
@@ -8471,10 +13245,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_blinknode_decode() != 54938) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_blinknode_decode_offer() != 53790) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_blinknode_get_info() != 19853) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_blinknode_get_offer() != 40807) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_blinknode_get_permissions() != 26975) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_blinknode_list_offers() != 40534) {
@@ -8495,6 +13275,15 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_blinknode_pay_offer() != 62903) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_blinknode_pay_onchain() != 7146) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_blinknode_pay_onchain_with_options() != 54725) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_blinknode_prepare_onchain_transaction() != 22869) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_clnnode_create_invoice() != 60752) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -8504,10 +13293,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_clnnode_decode() != 51992) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_clnnode_decode_offer() != 57101) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_clnnode_get_info() != 36197) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_clnnode_get_offer() != 28823) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_clnnode_get_permissions() != 33970) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_clnnode_list_offers() != 62186) {
@@ -8528,37 +13323,184 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_clnnode_pay_offer() != 54278) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_get_info() != 63939) {
+    if (uniffi_lni_checksum_method_flashnode_create_invoice() != 62040) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_create_invoice() != 58493) {
+    if (uniffi_lni_checksum_method_flashnode_create_offer() != 51307) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_pay_invoice() != 48894) {
+    if (uniffi_lni_checksum_method_flashnode_decode() != 3383) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_create_offer() != 56287) {
+    if (uniffi_lni_checksum_method_flashnode_decode_offer() != 9209) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_get_offer() != 42130) {
+    if (uniffi_lni_checksum_method_flashnode_galoy() != 15656) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_list_offers() != 42685) {
+    if (uniffi_lni_checksum_method_flashnode_get_info() != 18678) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_pay_offer() != 26809) {
+    if (uniffi_lni_checksum_method_flashnode_get_offer() != 18149) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_lookup_invoice() != 31149) {
+    if (uniffi_lni_checksum_method_flashnode_get_permissions() != 29929) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_list_transactions() != 42286) {
+    if (uniffi_lni_checksum_method_flashnode_list_offers() != 13682) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_decode() != 11638) {
+    if (uniffi_lni_checksum_method_flashnode_list_transactions() != 20043) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_lightningnode_on_invoice_events() != 18613) {
+    if (uniffi_lni_checksum_method_flashnode_lookup_invoice() != 23263) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_flashnode_on_invoice_events() != 24017) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_flashnode_pay_invoice() != 31343) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_flashnode_pay_invoice_with_status() != 24443) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_flashnode_pay_offer() != 6605) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_can_create_invoice() != 8909) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_create_invoice() != 15462) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_create_offer() != 12294) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_decode() != 35022) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_decode_offer() != 21322) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_get_info() != 53133) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_get_offer() != 48750) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_get_permissions() != 43996) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_list_offers() != 62815) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_list_transactions() != 26326) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_lookup_invoice() != 52072) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_on_invoice_events() != 21989) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_pay_invoice() != 9291) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_pay_invoice_with_status() != 18604) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_pay_offer() != 17077) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_pay_onchain() != 49759) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_pay_onchain_with_options() != 49747) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_galoynode_prepare_onchain_transaction() != 25834) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_create_invoice() != 28968) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_create_offer() != 35979) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_decode() != 46492) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_decode_offer() != 39770) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_get_human_bitcoin_address() != 43838) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_get_info() != 20991) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_get_offer() != 61977) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_get_permissions() != 2017) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_list_offers() != 48971) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_list_transactions() != 48199) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_lookup_invoice() != 8715) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_on_invoice_events() != 16391) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_pay_invoice() != 11535) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lexenode_pay_offer() != 61351) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_get_permissions() != 33385) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_get_info() != 3664) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_create_invoice() != 62349) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_pay_invoice() != 19156) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_create_offer() != 58734) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_get_offer() != 43381) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_list_offers() != 23265) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_pay_offer() != 60354) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_lookup_invoice() != 6421) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_list_transactions() != 42978) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_decode() != 54171) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_decode_offer() != 37439) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lightningnode_on_invoice_events() != 36036) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_lndnode_create_invoice() != 5254) {
@@ -8570,10 +13512,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_lndnode_decode() != 7091) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_lndnode_decode_offer() != 46048) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_lndnode_get_info() != 61919) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_lndnode_get_offer() != 60794) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_lndnode_get_permissions() != 25263) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_lndnode_list_offers() != 33463) {
@@ -8603,10 +13551,19 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_nwcnode_decode() != 7231) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_nwcnode_decode_offer() != 11964) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_nwcnode_get_info() != 65370) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_nwcnode_get_lightning_address() != 53252) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_nwcnode_get_offer() != 14257) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_nwcnode_get_permissions() != 19820) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_nwcnode_list_offers() != 27006) {
@@ -8642,13 +13599,19 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_phoenixdnode_create_offer() != 39667) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_lni_checksum_method_phoenixdnode_decode() != 20826) {
+    if (uniffi_lni_checksum_method_phoenixdnode_decode() != 22) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_phoenixdnode_decode_offer() != 52286) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_phoenixdnode_get_info() != 1217) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_phoenixdnode_get_offer() != 28141) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_phoenixdnode_get_permissions() != 24693) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_phoenixdnode_list_offers() != 50531) {
@@ -8678,6 +13641,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_sparknode_decode() != 60941) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_sparknode_decode_offer() != 64618) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_sparknode_disconnect() != 32412) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -8688,6 +13654,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_sparknode_get_offer() != 59868) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_sparknode_get_permissions() != 60237) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_sparknode_get_spark_address() != 49506) {
@@ -8720,10 +13689,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_speednode_decode() != 5102) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_speednode_decode_offer() != 22514) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_speednode_get_info() != 30713) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_speednode_get_offer() != 32733) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_speednode_get_permissions() != 38539) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_speednode_list_offers() != 1177) {
@@ -8753,10 +13728,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_strikenode_decode() != 50868) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_strikenode_decode_offer() != 39214) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_method_strikenode_get_info() != 10078) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_strikenode_get_offer() != 7451) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_strikenode_get_permissions() != 58424) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_method_strikenode_list_offers() != 48221) {
@@ -8777,10 +13758,28 @@ private let initializationResult: InitializationResult = {
     if (uniffi_lni_checksum_method_strikenode_pay_offer() != 30630) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_lni_checksum_method_strikenode_pay_onchain() != 13800) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_strikenode_pay_onchain_with_options() != 17113) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_method_strikenode_prepare_onchain_transaction() != 57821) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_lni_checksum_constructor_blinknode_new() != 49992) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_constructor_clnnode_new() != 59940) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_constructor_flashnode_new() != 21697) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_constructor_galoynode_new() != 59120) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_lni_checksum_constructor_lexenode_new() != 47346) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_lni_checksum_constructor_lndnode_new() != 57532) {

--- a/bindings/typescript-arkade/package-lock.json
+++ b/bindings/typescript-arkade/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -21,12 +21,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.21"
+        "@sunnyln/lni": "^0.2.22"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-arkade/package.json
+++ b/bindings/typescript-arkade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-arkade",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": false,
   "description": "Optional Arkade Boltz adapter for @sunnyln/lni.",
   "type": "module",
@@ -52,7 +52,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/arkade-boltz.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.21"
+    "@sunnyln/lni": "^0.2.22"
   },
   "dependencies": {
     "@arkade-os/boltz-swap": "^0.3.3",

--- a/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-expo-go/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -50,12 +50,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.21"
+        "@sunnyln/lni": "^0.2.22"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript-spark/examples/spark-web/package-lock.json
+++ b/bindings/typescript-spark/examples/spark-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -43,12 +43,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.21"
+        "@sunnyln/lni": "^0.2.22"
       }
     },
     "../../../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",
@@ -74,7 +74,7 @@
     },
     "../../../typescript-arkade": {
       "name": "@sunnyln/lni-arkade",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@arkade-os/boltz-swap": "^0.3.3",
         "@arkade-os/sdk": "^0.4.4"
@@ -89,7 +89,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.21"
+        "@sunnyln/lni": "^0.2.22"
       }
     },
     "node_modules/@arkade-os/boltz-swap": {

--- a/bindings/typescript-spark/package-lock.json
+++ b/bindings/typescript-spark/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni-spark",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@buildonspark/spark-sdk": "^0.6.3",
         "@frosts/core": "^0.2.2-alpha.3",
@@ -29,12 +29,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sunnyln/lni": "^0.2.21"
+        "@sunnyln/lni": "^0.2.22"
       }
     },
     "../typescript": {
       "name": "@sunnyln/lni",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dev": true,
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/bindings/typescript-spark/package.json
+++ b/bindings/typescript-spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni-spark",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": false,
   "description": "Optional Spark adapter for @sunnyln/lni with browser and Expo compatible pure TypeScript signer patching.",
   "type": "module",
@@ -56,7 +56,7 @@
     "test:integration": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --env-file=../../crates/lni/.env ./node_modules/vitest/vitest.mjs run src/__tests__/integration/spark.real.test.ts"
   },
   "peerDependencies": {
-    "@sunnyln/lni": "^0.2.21"
+    "@sunnyln/lni": "^0.2.22"
   },
   "dependencies": {
     "@buildonspark/spark-sdk": "^0.6.3",

--- a/bindings/typescript/README.md
+++ b/bindings/typescript/README.md
@@ -417,7 +417,7 @@ const invoice = await arkadeNode.createInvoice({
 - For local `file:` package development with Expo, build the package first (`bindings/typescript`: `npm run build`) and use the Expo example `metro.config.js` pattern for `./dist/*` resolution.
 - You can inject custom fetch via constructor options:
   - `new LndNode(config, { fetch: customFetch })`
-- React Native's legacy fetch follows redirects even when `redirect: 'error'` is requested. Use a redirect-capable transport such as `expo/fetch` and pass `{ fetch: expoFetch, fetchSupportsRedirectError: true }`.
+- Requests use `redirect: 'error'` as a best-effort redirect policy. React Native consumers can install a redirect-capable transport such as `expo/fetch` as the global fetch or pass it with `{ fetch: expoFetch }`.
 - Most backends require secrets (API keys, macaroons, runes, passwords). For production web apps, use a backend proxy/BFF to protect credentials.
 
 ## Security Scanner Notes

--- a/bindings/typescript/package-lock.json
+++ b/bindings/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunnyln/lni",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",
         "@scure/base": "^2.0.0",

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunnyln/lni",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": false,
   "description": "Lightning Node Interface. Connect to CLN, LND, Phoenixd, NWC, Strike, Speed and Blink. Supports BOLT11, BOLT12, LNURL and Lightning Address.",
   "type": "module",

--- a/bindings/typescript/src/__tests__/redirect-policy.test.ts
+++ b/bindings/typescript/src/__tests__/redirect-policy.test.ts
@@ -7,6 +7,7 @@ import { SpeedNode } from '../nodes/speed.js';
 import type { FetchLike, LightningNode, NodeRequestOptions } from '../types.js';
 
 const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+const originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
 
 function useReactNativeRuntime(): void {
   Object.defineProperty(globalThis, 'navigator', {
@@ -62,6 +63,12 @@ afterEach(() => {
   } else {
     delete (globalThis as { navigator?: Navigator }).navigator;
   }
+
+  if (originalFetchDescriptor) {
+    Object.defineProperty(globalThis, 'fetch', originalFetchDescriptor);
+  } else {
+    delete (globalThis as { fetch?: typeof fetch }).fetch;
+  }
 });
 
 describe('HTTP redirect policy', () => {
@@ -96,27 +103,28 @@ describe('HTTP redirect policy', () => {
     expect(inits.every((init) => init.redirect === 'error')).toBe(true);
   });
 
-  it('rejects legacy React Native fetch before sending credentials', () => {
+  it('does not reject a React Native runtime at construction', () => {
     useReactNativeRuntime();
     const fetchMock = vi.fn<FetchLike>();
 
     expect(
       () => new ClnNode({ url: 'https://cln.test', rune: 'fake-rune' }, { fetch: fetchMock })
-    ).toThrow(/legacy fetch cannot reject redirects/);
-    expect(fetchMock).not.toHaveBeenCalled();
+    ).not.toThrow();
   });
 
-  it('accepts an explicitly redirect-capable React Native fetch', async () => {
+  it('uses a redirect-capable global fetch in React Native without a capability flag', async () => {
     useReactNativeRuntime();
     const inits: RequestInit[] = [];
     const fetchMock = vi.fn<FetchLike>(async (_input, init) => {
       inits.push(init ?? {});
       return new Response('request failed', { status: 500 });
     });
-    const node = new ClnNode(
-      { url: 'https://cln.test', rune: 'fake-rune' },
-      { fetch: fetchMock, fetchSupportsRedirectError: true }
-    );
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: fetchMock,
+    });
+    const node = new ClnNode({ url: 'https://cln.test', rune: 'fake-rune' });
 
     await node.getInfo().catch(() => undefined);
 
@@ -125,22 +133,7 @@ describe('HTTP redirect policy', () => {
   });
 
   it.each(additionalNodeFactories)(
-    'rejects legacy React Native fetch for $name before sending credentials',
-    ({ create }) => {
-      useReactNativeRuntime();
-      const fetchMock = vi.fn<FetchLike>();
-
-      for (const fetchSupportsRedirectError of [undefined, false]) {
-        expect(() => create({ fetch: fetchMock, fetchSupportsRedirectError })).toThrow(
-          /legacy fetch cannot reject redirects/
-        );
-      }
-      expect(fetchMock).not.toHaveBeenCalled();
-    }
-  );
-
-  it.each(additionalNodeFactories)(
-    'uses redirect:error for $name with an explicitly capable React Native fetch',
+    'uses redirect:error for $name in React Native without a capability flag',
     async ({ create }) => {
       useReactNativeRuntime();
       const inits: RequestInit[] = [];
@@ -148,7 +141,7 @@ describe('HTTP redirect policy', () => {
         inits.push(init ?? {});
         return new Response('request failed', { status: 500 });
       });
-      const node = create({ fetch: fetchMock, fetchSupportsRedirectError: true });
+      const node = create({ fetch: fetchMock });
 
       await node.getInfo().catch(() => undefined);
 

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NwcError } from '../errors.js';
+import { emptyTransaction, matchesSearch } from '../internal/transform.js';
 import { StrikeNode } from '../nodes/strike.js';
 import type { FetchLike } from '../types.js';
 
@@ -664,5 +665,297 @@ describe('StrikeNode on-chain payments', () => {
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('StrikeNode transaction reconciliation', () => {
+  const paymentId = '11111111-1111-4111-8111-111111111111';
+
+  function transactionFetch({
+    receives = [],
+    payments = [],
+    direct,
+  }: {
+    receives?: unknown[];
+    payments?: unknown[];
+    direct?: unknown | '404';
+  }): ReturnType<typeof vi.fn<FetchLike>> {
+    return vi.fn<FetchLike>(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith(`/payments/${paymentId}`)) {
+        return direct === '404' ? new Response('not found', { status: 404 }) : jsonResponse(direct);
+      }
+      if (url.pathname.endsWith('/receive-requests/receives')) {
+        return jsonResponse({ items: receives, count: receives.length });
+      }
+      if (url.pathname.endsWith('/payments')) {
+        return jsonResponse({ data: payments, count: payments.length });
+      }
+      return new Response('not found', { status: 404 });
+    });
+  }
+
+  function node(fetch: FetchLike): StrikeNode {
+    return new StrikeNode(
+      { apiKey: 'test-token', baseUrl: 'https://api.strike.test/v1' },
+      { fetch }
+    );
+  }
+
+  it('searches every shared transaction text identifier case-insensitively', () => {
+    const transaction = emptyTransaction({
+      invoice: 'LN-INVOICE',
+      paymentHash: 'HASH-ABC',
+      description: 'Coffee Beans',
+      payerNote: 'Table Seven',
+      externalId: 'EXTERNAL-ID',
+      txid: 'BITCOIN-TXID',
+    });
+
+    for (const search of ['invoice', 'hash-a', 'COFFEE', 'seven', 'external', 'bitcoin-tx']) {
+      expect(matchesSearch(transaction, search)).toBe(true);
+    }
+  });
+
+  it('directly retrieves a UUID payment outside the page and replaces a listed copy', async () => {
+    const fetchMock = transactionFetch({
+      payments: [
+        {
+          id: paymentId,
+          state: 'PENDING',
+          created: '2026-01-01T00:00:00Z',
+          amount: { amount: '0.00000001', currency: 'BTC' },
+        },
+      ],
+      direct: {
+        paymentId,
+        state: 'COMPLETED',
+        completed: '2026-01-01T00:01:00Z',
+        amount: { amount: '0.00000001', currency: 'BTC' },
+      },
+    });
+
+    const transactions = await node(fetchMock).listTransactions({
+      from: 0,
+      limit: 1,
+      search: paymentId,
+    });
+
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]).toMatchObject({
+      externalId: paymentId,
+      settlementType: 'intraledger',
+      settlementState: 'completed',
+    });
+    expect(transactions[0]?.txid).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back after a direct 404 and never directly retrieves non-UUID searches', async () => {
+    const listed = {
+      id: paymentId,
+      state: 'PENDING',
+      created: '2026-01-01T00:00:00Z',
+      description: 'reconciliation target',
+      amount: { amount: '0.00000001', currency: 'BTC' },
+    };
+    const uuidFetch = transactionFetch({ payments: [listed], direct: '404' });
+    await expect(
+      node(uuidFetch).listTransactions({ from: 0, limit: 10, search: paymentId })
+    ).resolves.toHaveLength(1);
+
+    const textFetch = transactionFetch({ payments: [listed] });
+    await expect(
+      node(textFetch).listTransactions({ from: 0, limit: 10, search: 'TARGET' })
+    ).resolves.toHaveLength(1);
+    expect(textFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps outgoing lifecycle and route evidence independently', async () => {
+    const payments = [
+      { id: 'methodless-pending', state: 'PENDING' },
+      { id: 'methodless-completed', state: 'SUCCESS' },
+      { id: 'p2p-pending', type: 'P2P', state: 'PENDING', p2p: { recipient: 'x' } },
+      { id: 'onchain-completed-direct', type: 'ONCHAIN', state: 'COMPLETED' },
+      { id: 'onchain-pending', type: 'ONCHAIN', state: 'PENDING', onchain: {} },
+      {
+        id: 'onchain-pending-txid',
+        type: 'ONCHAIN',
+        state: 'PENDING',
+        onchain: { txnId: 'pending-txid' },
+      },
+      {
+        id: 'onchain-completed-txid',
+        state: 'COMPLETED',
+        onchain: { txnId: 'completed-txid' },
+      },
+      { id: 'failed', type: 'ONCHAIN', state: 'FAILURE' },
+      { id: 'unknown', state: 'SOMETHING_NEW' },
+      { id: 'lightning', state: 'COMPLETED', lightning: { paymentHash: 'hash' } },
+    ].map((payment, index) => ({
+      created: `2026-01-01T00:00:${String(index).padStart(2, '0')}Z`,
+      amount: { amount: '0.00000001', currency: 'BTC' },
+      ...payment,
+    }));
+    const transactions = await node(transactionFetch({ payments })).listTransactions({
+      from: 0,
+      limit: 50,
+    });
+    const byId = new Map(transactions.map((transaction) => [transaction.externalId, transaction]));
+
+    expect(byId.get('methodless-pending')).toMatchObject({
+      settlementType: 'unknown',
+      settlementState: 'pending',
+    });
+    expect(byId.get('methodless-completed')).toMatchObject({
+      settlementType: 'intraledger',
+      settlementState: 'completed',
+    });
+    expect(byId.get('p2p-pending')).toMatchObject({
+      settlementType: 'intraledger',
+      settlementState: 'pending',
+    });
+    expect(byId.get('onchain-completed-direct')).toMatchObject({
+      settlementType: 'intraledger',
+      settlementState: 'completed',
+    });
+    expect(byId.get('onchain-pending')).toMatchObject({
+      settlementType: 'onchain',
+      settlementState: 'pending',
+    });
+    expect(byId.get('onchain-pending')?.txid).toBeUndefined();
+    expect(byId.get('onchain-pending-txid')).toMatchObject({
+      settlementType: 'onchain',
+      settlementState: 'pending',
+      txid: 'pending-txid',
+    });
+    expect(byId.get('onchain-completed-txid')).toMatchObject({
+      settlementType: 'onchain',
+      settlementState: 'completed',
+      txid: 'completed-txid',
+    });
+    expect(byId.get('failed')).toMatchObject({
+      settlementType: 'onchain',
+      settlementState: 'failed',
+    });
+    expect(byId.get('unknown')).toMatchObject({
+      settlementType: 'unknown',
+      settlementState: 'unknown',
+    });
+    expect(byId.get('lightning')).toMatchObject({
+      settlementType: 'lightning',
+      settlementState: 'completed',
+    });
+    expect(byId.get('lightning')?.txid).toBeUndefined();
+  });
+
+  it('keeps a P2P provider ID and route stable as lifecycle advances', async () => {
+    let state = 'PENDING';
+    const fetchMock = vi.fn<FetchLike>(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/receive-requests/receives')) {
+        return jsonResponse({ items: [], count: 0 });
+      }
+      if (url.pathname.endsWith('/payments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'p2p-stable',
+              type: 'P2P',
+              state,
+              created: '2026-01-01T00:00:00Z',
+              amount: { amount: '0.00000001', currency: 'BTC' },
+              p2p: {},
+            },
+          ],
+        });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const strike = node(fetchMock);
+    const [pending] = await strike.listTransactions({ from: 0, limit: 10 });
+    state = 'COMPLETED';
+    const [completed] = await strike.listTransactions({ from: 0, limit: 10 });
+
+    expect(pending).toMatchObject({
+      externalId: 'p2p-stable',
+      settlementType: 'intraledger',
+      settlementState: 'pending',
+    });
+    expect(completed).toMatchObject({
+      externalId: 'p2p-stable',
+      settlementType: 'intraledger',
+      settlementState: 'completed',
+    });
+  });
+
+  it('retains incoming P2P and onchain receives with provider IDs and txids', async () => {
+    const receives = [
+      {
+        receiveId: 'receive-p2p',
+        receiveRequestId: 'request-p2p',
+        type: 'P2P',
+        state: 'PENDING',
+        created: '2026-01-01T00:00:00Z',
+        amountReceived: { amount: '0.00000001', currency: 'BTC' },
+        p2p: {},
+      },
+      {
+        receiveId: 'receive-direct',
+        receiveRequestId: 'request-direct',
+        type: 'ONCHAIN',
+        state: 'COMPLETED',
+        created: '2026-01-01T00:00:01Z',
+        amountReceived: { amount: '0.00000001', currency: 'BTC' },
+        onchain: { address: 'bc1q' },
+      },
+      {
+        receiveId: 'receive-chain',
+        receiveRequestId: 'request-chain',
+        type: 'ONCHAIN',
+        state: 'COMPLETED',
+        created: '2026-01-01T00:00:02Z',
+        amountReceived: { amount: '0.00000001', currency: 'BTC' },
+        onchain: { address: 'bc1q', transactionId: 'receive-txid' },
+      },
+    ];
+    const transactions = await node(transactionFetch({ receives })).listTransactions({
+      from: 0,
+      limit: 10,
+    });
+    const byId = new Map(transactions.map((transaction) => [transaction.externalId, transaction]));
+
+    expect(byId.get('receive-p2p')).toMatchObject({
+      settlementType: 'intraledger',
+      settlementState: 'pending',
+    });
+    expect(byId.get('receive-direct')).toMatchObject({
+      settlementType: 'intraledger',
+      settlementState: 'completed',
+    });
+    expect(byId.get('receive-chain')).toMatchObject({
+      settlementType: 'onchain',
+      settlementState: 'completed',
+      txid: 'receive-txid',
+    });
+  });
+
+  it('matches outgoing txids during list filtering', async () => {
+    const transactions = await node(
+      transactionFetch({
+        payments: [
+          {
+            id: 'payment-with-txid',
+            state: 'PENDING',
+            created: '2026-01-01T00:00:00Z',
+            amount: { amount: '0.00000001', currency: 'BTC' },
+            onchain: { txnId: 'ABCDEF012345' },
+          },
+        ],
+      })
+    ).listTransactions({ from: 0, limit: 10, search: 'cdef01' });
+
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]?.externalId).toBe('payment-with-txid');
   });
 });

--- a/bindings/typescript/src/__tests__/strike.test.ts
+++ b/bindings/typescript/src/__tests__/strike.test.ts
@@ -717,21 +717,23 @@ describe('StrikeNode transaction reconciliation', () => {
     }
   });
 
-  it('directly retrieves a UUID payment outside the page and replaces a listed copy', async () => {
+  it('directly retrieves a UUID payment and preserves fields omitted by its latest snapshot', async () => {
     const fetchMock = transactionFetch({
       payments: [
         {
           id: paymentId,
+          type: 'ONCHAIN',
           state: 'PENDING',
           created: '2026-01-01T00:00:00Z',
+          description: 'listed description',
           amount: { amount: '0.00000001', currency: 'BTC' },
+          onchain: { txnId: 'listed-txid' },
         },
       ],
       direct: {
         paymentId,
         state: 'COMPLETED',
         completed: '2026-01-01T00:01:00Z',
-        amount: { amount: '0.00000001', currency: 'BTC' },
       },
     });
 
@@ -744,11 +746,31 @@ describe('StrikeNode transaction reconciliation', () => {
     expect(transactions).toHaveLength(1);
     expect(transactions[0]).toMatchObject({
       externalId: paymentId,
-      settlementType: 'intraledger',
+      amountMsats: 1_000,
+      createdAt: 1_767_225_600,
+      settledAt: 1_767_225_660,
+      description: 'listed description',
+      settlementType: 'onchain',
       settlementState: 'completed',
+      txid: 'listed-txid',
     });
-    expect(transactions[0]?.txid).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses a deterministic identifier tie-breaker before applying the limit', async () => {
+    const payments = ['payment-z', 'payment-a'].map((id) => ({
+      id,
+      state: 'PENDING',
+      created: '2026-01-01T00:00:00Z',
+      amount: { amount: '0.00000001', currency: 'BTC' },
+    }));
+
+    const transactions = await node(transactionFetch({ payments })).listTransactions({
+      from: 0,
+      limit: 1,
+    });
+
+    expect(transactions.map((transaction) => transaction.externalId)).toEqual(['payment-a']);
   });
 
   it('falls back after a direct 404 and never directly retrieves non-UUID searches', async () => {

--- a/bindings/typescript/src/internal/http.ts
+++ b/bindings/typescript/src/internal/http.ts
@@ -14,17 +14,7 @@ export interface RequestArgs {
   signal?: AbortSignal;
 }
 
-export function resolveFetch(
-  customFetch?: FetchLike,
-  fetchSupportsRedirectError = false
-): FetchLike {
-  if (globalThis.navigator?.product === 'ReactNative' && !fetchSupportsRedirectError) {
-    throw new LniError(
-      'InvalidInput',
-      "React Native's legacy fetch cannot reject redirects. Supply a redirect-capable fetch such as expo/fetch and set fetchSupportsRedirectError: true."
-    );
-  }
-
+export function resolveFetch(customFetch?: FetchLike): FetchLike {
   if (customFetch) {
     return customFetch;
   }

--- a/bindings/typescript/src/internal/transform.ts
+++ b/bindings/typescript/src/internal/transform.ts
@@ -109,6 +109,8 @@ export function matchesSearch(tx: Transaction, search?: string): boolean {
     tx.paymentHash.toLowerCase().includes(normalized) ||
     tx.description.toLowerCase().includes(normalized) ||
     (tx.payerNote ?? '').toLowerCase().includes(normalized) ||
-    tx.invoice.toLowerCase().includes(normalized)
+    tx.invoice.toLowerCase().includes(normalized) ||
+    (tx.externalId ?? '').toLowerCase().includes(normalized) ||
+    (tx.txid ?? '').toLowerCase().includes(normalized)
   );
 }

--- a/bindings/typescript/src/lnurl.ts
+++ b/bindings/typescript/src/lnurl.ts
@@ -8,8 +8,6 @@ export type PaymentDestinationType = 'bolt11' | 'bolt12' | 'lnurl' | 'lightning_
 
 export interface LnurlResolverOptions {
   fetch?: FetchLike;
-  /** Required in React Native when the supplied fetch honors `redirect: 'error'`. */
-  fetchSupportsRedirectError?: boolean;
   /**
    * Allows non-HTTPS or private/internal LNURL endpoints. Intended only for
    * local development or caller-provided URL allowlisting.
@@ -399,7 +397,7 @@ export async function verifyLightningAddressPayRequest(
   lightningAddress: string,
   options: LnurlResolverOptions = {}
 ): Promise<{ wellKnown: LnurlPayResponse; verifyEndpoint: string }> {
-  const fetchFn = resolveFetch(options?.fetch, options?.fetchSupportsRedirectError);
+  const fetchFn = resolveFetch(options.fetch);
   const { user, domain } = parseLightningAddress(lightningAddress.trim());
   const wellKnown = await fetchLnurlPay(lightningAddressToUrl(user, domain), fetchFn, options);
   const amountMsats = Math.min(Math.max(100_000, wellKnown.minSendable), wellKnown.maxSendable);
@@ -463,7 +461,7 @@ export async function resolveToBolt11(
   amountMsats?: number,
   options: LnurlResolverOptions = {}
 ): Promise<string> {
-  const fetchFn = resolveFetch(options?.fetch, options?.fetchSupportsRedirectError);
+  const fetchFn = resolveFetch(options.fetch);
   const destinationType = detectPaymentType(destination);
 
   if (destinationType === 'bolt11') {
@@ -495,7 +493,7 @@ export async function getPaymentInfo(
   amountMsats?: number,
   options: LnurlResolverOptions = {}
 ): Promise<PaymentInfo> {
-  const fetchFn = resolveFetch(options?.fetch, options?.fetchSupportsRedirectError);
+  const fetchFn = resolveFetch(options.fetch);
   const destinationType = detectPaymentType(destination);
 
   if (destinationType === 'bolt11' || destinationType === 'bolt12') {

--- a/bindings/typescript/src/nodes/cln.ts
+++ b/bindings/typescript/src/nodes/cln.ts
@@ -159,7 +159,7 @@ export class ClnNode implements LightningNode {
     private readonly config: ClnConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
   }
 

--- a/bindings/typescript/src/nodes/galoy.ts
+++ b/bindings/typescript/src/nodes/galoy.ts
@@ -480,7 +480,7 @@ class GaloyNodeImplementation implements LightningNode, OnchainPayments {
     private readonly config: GaloyConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
     this.baseUrl = config.baseUrl;
   }

--- a/bindings/typescript/src/nodes/lnd.ts
+++ b/bindings/typescript/src/nodes/lnd.ts
@@ -173,7 +173,7 @@ export class LndNode implements LightningNode {
     private readonly config: LndConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
   }
 

--- a/bindings/typescript/src/nodes/nwc.ts
+++ b/bindings/typescript/src/nodes/nwc.ts
@@ -260,7 +260,6 @@ export class NwcNode implements LightningNode {
     try {
       await verifyLightningAddressPayRequest(lightningAddress, {
         fetch: this.options.fetch,
-        fetchSupportsRedirectError: this.options.fetchSupportsRedirectError,
       });
       lnurlVerifySupported = true;
     } catch (error) {

--- a/bindings/typescript/src/nodes/phoenixd.ts
+++ b/bindings/typescript/src/nodes/phoenixd.ts
@@ -173,7 +173,7 @@ export class PhoenixdNode implements LightningNode {
     private readonly config: PhoenixdConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
   }
 

--- a/bindings/typescript/src/nodes/speed.ts
+++ b/bindings/typescript/src/nodes/speed.ts
@@ -105,7 +105,7 @@ export class SpeedNode implements LightningNode {
     private readonly config: SpeedConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
     this.baseUrl = config.baseUrl ?? 'https://api.tryspeed.com';
   }

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -42,6 +42,8 @@ import {
   type Permissions,
   type OnchainTransaction,
   type PrepareOnchainTransactionParams,
+  type SettlementState,
+  type SettlementType,
   type StrikeConfig,
   type Transaction,
 } from '../types.js';
@@ -93,19 +95,22 @@ interface StrikePaymentExecutionResponse {
 }
 
 interface StrikePaymentResponse {
-  id: string;
+  id?: string;
   paymentId?: string;
-  state: string;
-  created: string;
+  type?: string;
+  state?: string;
+  result?: string;
+  created?: string;
   completed?: string;
   description?: string;
-  amount: StrikeAmount;
+  amount?: StrikeAmount;
   totalFee?: StrikeAmount;
   totalAmount?: StrikeAmount;
   lightning?: StrikeLightningPaymentDetails;
   onchain?: {
     txnId?: string;
   };
+  p2p?: Record<string, unknown>;
 }
 
 interface StrikeOnchainTierResponse {
@@ -130,25 +135,151 @@ interface DuplicatePaymentQuote {
   raw: unknown;
 }
 
+interface StrikeReceive {
+  receiveId?: string;
+  receiveRequestId?: string;
+  type?: string;
+  state?: string;
+  created?: string;
+  completed?: string;
+  amountReceived: StrikeAmount;
+  lightning?: {
+    invoice?: string;
+    preimage?: string;
+    description?: string;
+    descriptionHash?: string;
+    paymentHash?: string;
+  };
+  onchain?: {
+    address?: string;
+    transactionId?: string;
+    transactionHash?: string;
+    outputIndex?: number;
+    blockHeight?: number;
+    numberOfConfirmations?: number;
+  };
+  p2p?: Record<string, unknown>;
+}
+
 interface StrikeReceivesResponse {
-  items: Array<{
-    receiveRequestId: string;
-    state: string;
-    created: string;
-    completed?: string;
-    amountReceived: StrikeAmount;
-    lightning?: {
-      invoice: string;
-      preimage: string;
-      description?: string;
-      descriptionHash?: string;
-      paymentHash: string;
-    };
-  }>;
+  items: StrikeReceive[];
 }
 
 interface StrikePaymentsResponse {
   data: StrikePaymentResponse[];
+}
+
+function normalizeSettlementState(state?: string): SettlementState {
+  switch (state?.toUpperCase()) {
+    case 'PENDING':
+      return 'pending';
+    case 'COMPLETED':
+    case 'SUCCESS':
+      return 'completed';
+    case 'FAILED':
+    case 'FAILURE':
+      return 'failed';
+    default:
+      return 'unknown';
+  }
+}
+
+function normalizeSettlementType(input: {
+  type?: string;
+  state?: string;
+  lightning?: unknown;
+  onchain?: unknown;
+  p2p?: unknown;
+  txid?: string;
+}): SettlementType {
+  const type = input.type?.toUpperCase();
+  const state = normalizeSettlementState(input.state);
+
+  if (input.txid) return 'onchain';
+  if (type === 'P2P' || input.p2p) return 'intraledger';
+  if (type === 'LIGHTNING' || input.lightning) return 'lightning';
+  if (state === 'completed') return 'intraledger';
+  if (type === 'ONCHAIN' || input.onchain) return 'onchain';
+  return 'unknown';
+}
+
+function normalizedPaymentId(payment: StrikePaymentResponse): string | undefined {
+  return payment.paymentId ?? payment.id;
+}
+
+function strikeAmountToMsats(amount?: StrikeAmount): number {
+  return amount?.currency === 'BTC' ? btcToMsats(amount.amount) : 0;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function strikePaymentToTransaction(payment: StrikePaymentResponse): Transaction {
+  const state = payment.state ?? payment.result;
+  const providerTxid = payment.onchain?.txnId;
+  const txid = providerTxid?.trim() ? providerTxid : undefined;
+
+  return emptyTransaction({
+    type: 'outgoing',
+    invoice: payment.lightning?.paymentRequest ?? '',
+    preimage: payment.lightning?.preImage ?? '',
+    paymentHash: payment.lightning?.paymentHash ?? '',
+    amountMsats: strikeAmountToMsats(payment.amount),
+    feesPaid: payment.lightning?.networkFee ? strikeAmountToMsats(payment.lightning.networkFee) : 0,
+    createdAt: payment.created ? toUnixSeconds(Date.parse(payment.created)) : 0,
+    settledAt:
+      normalizeSettlementState(state) === 'completed' && payment.completed
+        ? toUnixSeconds(Date.parse(payment.completed))
+        : 0,
+    description: payment.description ?? '',
+    externalId: normalizedPaymentId(payment),
+    payerNote: '',
+    settlementType: normalizeSettlementType({
+      type: payment.type,
+      state,
+      lightning: payment.lightning,
+      onchain: payment.onchain,
+      p2p: payment.p2p,
+      txid,
+    }),
+    settlementState: normalizeSettlementState(state),
+    txid,
+  });
+}
+
+function strikeReceiveToTransaction(receive: StrikeReceive): Transaction {
+  const providerTxid = receive.onchain?.transactionId ?? receive.onchain?.transactionHash;
+  const txid = providerTxid?.trim() ? providerTxid : undefined;
+  const lightning = receive.lightning;
+
+  return emptyTransaction({
+    type: 'incoming',
+    invoice: lightning?.invoice ?? '',
+    preimage: lightning?.preimage ?? '',
+    paymentHash: lightning?.paymentHash ?? '',
+    amountMsats: strikeAmountToMsats(receive.amountReceived),
+    feesPaid: 0,
+    createdAt: receive.created ? toUnixSeconds(Date.parse(receive.created)) : 0,
+    settledAt:
+      normalizeSettlementState(receive.state) === 'completed' && receive.completed
+        ? toUnixSeconds(Date.parse(receive.completed))
+        : 0,
+    description: lightning?.description ?? lightning?.descriptionHash ?? '',
+    descriptionHash: lightning?.descriptionHash ?? '',
+    externalId: receive.receiveId ?? receive.receiveRequestId,
+    payerNote: '',
+    settlementType: normalizeSettlementType({
+      type: receive.type,
+      state: receive.state,
+      lightning,
+      onchain: receive.onchain,
+      p2p: receive.p2p,
+      txid,
+    }),
+    settlementState: normalizeSettlementState(receive.state),
+    txid,
+  });
 }
 
 function paymentHashFromInvoice(invoice: string): string {
@@ -449,7 +580,7 @@ export class StrikeNode implements LightningNode, OnchainPayments {
     private readonly config: StrikeConfig,
     options: NodeRequestOptions = {}
   ) {
-    this.fetchFn = resolveFetch(options.fetch, options.fetchSupportsRedirectError);
+    this.fetchFn = resolveFetch(options.fetch);
     this.timeoutMs = toTimeoutMs(config.httpTimeout);
     this.baseUrl = config.baseUrl ?? 'https://api.strike.me/v1';
   }
@@ -892,105 +1023,71 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       throw new LniError('Api', `No receive found for payment hash: ${params.paymentHash}`);
     }
 
-    return emptyTransaction({
-      type: 'incoming',
-      invoice: item.lightning.invoice,
-      preimage: item.lightning.preimage,
-      paymentHash: item.lightning.paymentHash,
-      amountMsats: btcToMsats(item.amountReceived.amount),
-      feesPaid: 0,
-      createdAt: toUnixSeconds(Date.parse(item.created)),
-      settledAt:
-        item.state === 'COMPLETED' && item.completed
-          ? toUnixSeconds(Date.parse(item.completed))
-          : 0,
-      description: item.lightning.description ?? item.lightning.descriptionHash ?? '',
-      descriptionHash: item.lightning.descriptionHash ?? '',
-      externalId: item.receiveRequestId,
-      payerNote: '',
-    });
+    return strikeReceiveToTransaction(item);
   }
 
   async listTransactions(params: ListTransactionsParams): Promise<Transaction[]> {
-    const receives = await this.getJson<StrikeReceivesResponse>(
-      '/receive-requests/receives',
-      {
-        $skip: params.from,
-        $top: params.limit,
-      },
-      'list_transactions'
-    );
+    const search = params.search;
+    const directPaymentPromise =
+      search && isUuid(search)
+        ? this.getJson<StrikePaymentResponse>(
+            `/payments/${encodeURIComponent(search)}`,
+            undefined,
+            'list_transactions'
+          ).catch(() => undefined)
+        : Promise.resolve(undefined);
 
-    let outgoing: StrikePaymentsResponse = { data: [] };
-    try {
-      outgoing = await this.getJson<StrikePaymentsResponse>(
+    const [receives, outgoing, directPayment] = await Promise.all([
+      this.getJson<StrikeReceivesResponse>(
+        '/receive-requests/receives',
+        {
+          $skip: params.from,
+          $top: params.limit,
+        },
+        'list_transactions'
+      ),
+      this.getJson<StrikePaymentsResponse>(
         '/payments',
         {
           $skip: params.from,
           $top: params.limit,
         },
         'list_transactions'
-      );
-    } catch (error) {
-      if (!this.isNotFoundError(error)) {
+      ).catch((error: unknown) => {
+        if (this.isNotFoundError(error)) {
+          return { data: [] };
+        }
         throw error;
-      }
-      // Strike can return 404 when there are no outgoing payments for the account.
+      }),
+      directPaymentPromise,
+    ]);
+
+    const transactions = new Map<string, Transaction>();
+    receives.items.forEach((receive, index) => {
+      const tx = strikeReceiveToTransaction(receive);
+      transactions.set(`incoming:${tx.externalId ?? index}`, tx);
+    });
+    outgoing.data.forEach((payment, index) => {
+      const tx = strikePaymentToTransaction(payment);
+      transactions.set(`outgoing:${normalizedPaymentId(payment) ?? index}`, tx);
+    });
+
+    // The single-payment endpoint is the freshest snapshot and replaces a listed copy.
+    if (directPayment) {
+      const tx = strikePaymentToTransaction(directPayment);
+      transactions.set(`outgoing:${normalizedPaymentId(directPayment) ?? search ?? 'direct'}`, tx);
     }
 
-    const txs: Transaction[] = [];
-
-    for (const receive of receives.items) {
-      if (!receive.lightning) {
-        continue;
-      }
-
-      const tx = emptyTransaction({
-        type: 'incoming',
-        invoice: receive.lightning.invoice,
-        preimage: receive.lightning.preimage,
-        paymentHash: receive.lightning.paymentHash,
-        amountMsats: btcToMsats(receive.amountReceived.amount),
-        feesPaid: 0,
-        createdAt: toUnixSeconds(Date.parse(receive.created)),
-        settledAt:
-          receive.state === 'COMPLETED' && receive.completed
-            ? toUnixSeconds(Date.parse(receive.completed))
-            : 0,
-        description: receive.lightning.description ?? receive.lightning.descriptionHash ?? '',
-        descriptionHash: receive.lightning.descriptionHash ?? '',
-        externalId: receive.receiveRequestId,
-        payerNote: '',
-      });
-
-      txs.push(tx);
-    }
-
-    for (const payment of outgoing.data) {
-      const tx = emptyTransaction({
-        type: 'outgoing',
-        invoice: payment.lightning?.paymentRequest ?? '',
-        paymentHash: payment.lightning?.paymentHash ?? '',
-        amountMsats: btcToMsats(payment.amount.amount),
-        feesPaid: payment.lightning?.networkFee
-          ? btcToMsats(payment.lightning.networkFee.amount)
-          : 0,
-        createdAt: toUnixSeconds(Date.parse(payment.created)),
-        settledAt:
-          payment.state === 'COMPLETED' && payment.completed
-            ? toUnixSeconds(Date.parse(payment.completed))
-            : 0,
-        description: payment.description ?? '',
-        descriptionHash: '',
-        externalId: payment.id,
-        payerNote: '',
-      });
-
-      txs.push(tx);
-    }
+    const txs = [...transactions.values()];
 
     const filtered = txs.filter((tx) => {
       if (params.paymentHash && tx.paymentHash !== params.paymentHash) {
+        return false;
+      }
+      if (params.createdAfter !== undefined && tx.createdAt < params.createdAfter) {
+        return false;
+      }
+      if (params.createdBefore !== undefined && tx.createdAt > params.createdBefore) {
         return false;
       }
       return matchesSearch(tx, params.search);

--- a/bindings/typescript/src/nodes/strike.ts
+++ b/bindings/typescript/src/nodes/strike.ts
@@ -207,6 +207,50 @@ function normalizedPaymentId(payment: StrikePaymentResponse): string | undefined
   return payment.paymentId ?? payment.id;
 }
 
+function definedProperties<T extends object>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, property]) => property !== undefined)
+  ) as Partial<T>;
+}
+
+function mergePaymentSnapshots(
+  listed: StrikePaymentResponse,
+  direct: StrikePaymentResponse
+): StrikePaymentResponse {
+  const merged: StrikePaymentResponse = {
+    ...listed,
+    ...definedProperties(direct),
+  };
+
+  // `state` and `result` are alternate lifecycle fields. If the direct
+  // snapshot supplies either one, do not let the listed alias take precedence.
+  if (direct.state !== undefined || direct.result !== undefined) {
+    merged.state = direct.state;
+    merged.result = direct.result;
+  }
+
+  if (direct.lightning !== undefined) {
+    merged.lightning = {
+      ...listed.lightning,
+      ...definedProperties(direct.lightning),
+    };
+  }
+  if (direct.onchain !== undefined) {
+    merged.onchain = {
+      ...listed.onchain,
+      ...definedProperties(direct.onchain),
+    };
+  }
+  if (direct.p2p !== undefined) {
+    merged.p2p = {
+      ...listed.p2p,
+      ...definedProperties(direct.p2p),
+    };
+  }
+
+  return merged;
+}
+
 function strikeAmountToMsats(amount?: StrikeAmount): number {
   return amount?.currency === 'BTC' ? btcToMsats(amount.amount) : 0;
 }
@@ -1067,16 +1111,26 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       const tx = strikeReceiveToTransaction(receive);
       transactions.set(`incoming:${tx.externalId ?? index}`, tx);
     });
+
+    const payments = new Map<string, StrikePaymentResponse>();
     outgoing.data.forEach((payment, index) => {
-      const tx = strikePaymentToTransaction(payment);
-      transactions.set(`outgoing:${normalizedPaymentId(payment) ?? index}`, tx);
+      payments.set(`outgoing:${normalizedPaymentId(payment) ?? index}`, payment);
     });
 
-    // The single-payment endpoint is the freshest snapshot and replaces a listed copy.
+    // The single-payment endpoint is the freshest snapshot. Preserve fields it
+    // omits when the collection contained a more complete copy.
     if (directPayment) {
-      const tx = strikePaymentToTransaction(directPayment);
-      transactions.set(`outgoing:${normalizedPaymentId(directPayment) ?? search ?? 'direct'}`, tx);
+      const key = `outgoing:${normalizedPaymentId(directPayment) ?? search ?? 'direct'}`;
+      const listedPayment = payments.get(key);
+      payments.set(
+        key,
+        listedPayment ? mergePaymentSnapshots(listedPayment, directPayment) : directPayment
+      );
     }
+
+    payments.forEach((payment, key) => {
+      transactions.set(key, strikePaymentToTransaction(payment));
+    });
 
     const txs = [...transactions.values()];
 
@@ -1093,7 +1147,18 @@ export class StrikeNode implements LightningNode, OnchainPayments {
       return matchesSearch(tx, params.search);
     });
 
-    const sorted = filtered.sort((a, b) => b.createdAt - a.createdAt);
+    const sorted = filtered.sort((a, b) => {
+      const createdAtOrder = b.createdAt - a.createdAt;
+      if (createdAtOrder !== 0) return createdAtOrder;
+
+      const aKey = [a.type, a.externalId ?? '', a.paymentHash, a.txid ?? '', a.invoice];
+      const bKey = [b.type, b.externalId ?? '', b.paymentHash, b.txid ?? '', b.invoice];
+      for (let index = 0; index < aKey.length; index += 1) {
+        if (aKey[index] === bKey[index]) continue;
+        return (aKey[index] ?? '') < (bKey[index] ?? '') ? -1 : 1;
+      }
+      return 0;
+    });
     return sorted.slice(0, params.limit > 0 ? params.limit : undefined);
   }
 

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -33,6 +33,10 @@ export interface NodeInfo {
 
 export type TransactionType = 'incoming' | 'outgoing';
 
+export type SettlementType = 'lightning' | 'onchain' | 'intraledger' | 'unknown';
+
+export type SettlementState = 'pending' | 'completed' | 'failed' | 'unknown';
+
 export interface Transaction {
   type: TransactionType;
   invoice: string;
@@ -47,6 +51,9 @@ export interface Transaction {
   settledAt: number;
   payerNote?: string;
   externalId?: string;
+  settlementType?: SettlementType;
+  settlementState?: SettlementState;
+  txid?: string;
 }
 
 export interface PayInvoiceResponse {
@@ -188,8 +195,6 @@ export interface OnInvoiceEventParams {
 
 export interface NodeRequestOptions {
   fetch?: FetchLike;
-  /** Required in React Native when the supplied fetch honors `redirect: 'error'` (for example, `expo/fetch`). */
-  fetchSupportsRedirectError?: boolean;
 }
 
 export interface PhoenixdConfig {

--- a/crates/lni/cln/api.rs
+++ b/crates/lni/cln/api.rs
@@ -290,6 +290,9 @@ pub async fn create_invoice(
                 description_hash: description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some("".to_string()),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => {
@@ -317,6 +320,9 @@ pub async fn create_invoice(
                 description_hash: description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some("".to_string()),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
     }
@@ -762,6 +768,9 @@ async fn lookup_invoices(
                     description_hash: "".to_string(),
                     payer_note: Some(inv.invreq_payer_note.unwrap_or_default()),
                     external_id: Some(inv.label),
+                    settlement_type: None,
+                    settlement_state: None,
+                    txid: None,
                 })
                 .collect();
             transactions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -840,6 +849,9 @@ async fn lookup_invoices(
                 description_hash: "".to_string(),
                 payer_note: Some(inv.invreq_payer_note.unwrap_or("".to_string())),
                 external_id: Some(inv.label),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             }
         })
         .collect();

--- a/crates/lni/galoy/api.rs
+++ b/crates/lni/galoy/api.rs
@@ -654,6 +654,9 @@ pub async fn create_invoice(
                 description_hash: invoice_params.description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some("".to_string()),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => Err(provider_nwc_error(
@@ -1315,6 +1318,9 @@ async fn list_transactions_impl(
             description_hash: "".to_string(),
             payer_note: Some("".to_string()),
             external_id: Some(node.id),
+            settlement_type: None,
+            settlement_state: None,
+            txid: None,
         });
     }
 

--- a/crates/lni/lexe/api.rs
+++ b/crates/lni/lexe/api.rs
@@ -197,6 +197,9 @@ fn payment_to_transaction(payment: &Payment) -> Result<Transaction, ApiError> {
             .clone()
             .or_else(|| payment.personal_note.clone()),
         external_id: Some(payment.index.to_string()),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 
@@ -464,6 +467,9 @@ pub async fn create_invoice(
         settled_at: 0,
         payer_note: None,
         external_id: Some(response.index.to_string()),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 

--- a/crates/lni/lnd/api.rs
+++ b/crates/lni/lnd/api.rs
@@ -449,6 +449,9 @@ pub async fn lookup_invoice(
         description_hash: inv.description_hash.unwrap_or_default(), // TODO: what format should hash be in? hex or base64? does anyone care?
         payer_note: Some("".to_string()),
         external_id: Some("".to_string()),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 
@@ -606,6 +609,9 @@ pub async fn create_invoice(
         description_hash: params.description_hash.clone().unwrap_or_default(),
         payer_note: Some("".to_string()),
         external_id: Some("".to_string()),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 
@@ -795,6 +801,9 @@ pub async fn list_transactions(
             description_hash: inv.description_hash.unwrap_or_default(),
             payer_note: Some("".to_string()),
             external_id: Some("".to_string()),
+            settlement_type: None,
+            settlement_state: None,
+            txid: None,
         })
         .collect();
 

--- a/crates/lni/nwc/api.rs
+++ b/crates/lni/nwc/api.rs
@@ -235,6 +235,9 @@ pub async fn create_invoice(
         settled_at: 0, // Not settled yet
         payer_note: None,
         external_id: None,
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 
@@ -430,6 +433,9 @@ fn lookup_response_to_transaction(
             .unwrap_or(0),
         payer_note: None,
         external_id: None,
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     }
 }
 
@@ -523,18 +529,7 @@ fn transaction_matches_params(transaction: &Transaction, params: &ListTransactio
     }
 
     if let Some(search) = params.search.as_deref() {
-        let search = search.to_lowercase();
-        let matches_search = transaction.payment_hash.to_lowercase().contains(&search)
-            || transaction.invoice.to_lowercase().contains(&search)
-            || transaction.description.to_lowercase().contains(&search)
-            || transaction
-                .payer_note
-                .as_deref()
-                .unwrap_or_default()
-                .to_lowercase()
-                .contains(&search);
-
-        if !matches_search {
+        if !crate::transaction_matches_search(transaction, search) {
             return false;
         }
     }
@@ -787,6 +782,9 @@ mod tests {
             settled_at: 0,
             payer_note: None,
             external_id: None,
+            settlement_type: None,
+            settlement_state: None,
+            txid: None,
         };
 
         assert!(transaction_matches_lookup(&transaction, Some("hash"), None));

--- a/crates/lni/phoenixd/api.rs
+++ b/crates/lni/phoenixd/api.rs
@@ -234,6 +234,9 @@ pub async fn create_invoice(
                 description_hash: description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some("".to_string()),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => {
@@ -286,6 +289,9 @@ pub async fn create_invoice(
                 description_hash: description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some("".to_string()),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
     }
@@ -552,6 +558,9 @@ pub async fn lookup_invoice(
         description_hash: "".to_string(), // TODO
         payer_note: Some(inv.payer_note.unwrap_or("".to_string())),
         external_id: Some(inv.external_id.unwrap_or("".to_string())),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     };
     Ok(txn)
 }
@@ -638,6 +647,9 @@ pub async fn list_transactions(
             description_hash: "".to_string(),
             payer_note: Some(inc_payment.payer_note.unwrap_or("".to_string())),
             external_id: Some(inc_payment.external_id.unwrap_or("".to_string())),
+            settlement_type: None,
+            settlement_state: None,
+            txid: None,
         });
     }
 
@@ -718,6 +730,9 @@ pub async fn list_transactions(
             description_hash: "".to_string(),
             payer_note: Some(payment.payer_note.unwrap_or("".to_string())),
             external_id: Some(payment.external_id.unwrap_or("".to_string())),
+            settlement_type: None,
+            settlement_state: None,
+            txid: None,
         });
     }
 

--- a/crates/lni/spark/api.rs
+++ b/crates/lni/spark/api.rs
@@ -137,6 +137,9 @@ fn payment_to_transaction(payment: &breez_sdk_spark::Payment) -> Option<Transact
         description_hash: "".to_string(),
         payer_note: None,
         external_id: Some(payment.id.clone()),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     })
 }
 
@@ -223,6 +226,9 @@ pub async fn create_invoice(
                 description_hash: invoice_params.description_hash.unwrap_or_default(),
                 payer_note: None,
                 external_id: None,
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => Err(ApiError::Api {

--- a/crates/lni/speed/api.rs
+++ b/crates/lni/speed/api.rs
@@ -254,6 +254,9 @@ pub async fn create_invoice(
                 description_hash: invoice_params.description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some(payment.payment.id),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => Err(nwc_error(
@@ -499,6 +502,9 @@ fn convert_send_to_transaction(send_tx: SpeedSendResponse) -> Transaction {
         description_hash: "".to_string(),
         payer_note: send_tx.note,
         external_id: Some(send_tx.id),
+        settlement_type: None,
+        settlement_state: None,
+        txid: None,
     }
 }
 

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -6,9 +7,9 @@ use lightning_invoice::Bolt11Invoice;
 use super::types::{
     Amount, CreateReceiveRequestRequest, OnchainPaymentExecutionResponse,
     OnchainPaymentQuoteRequest, OnchainPaymentQuoteResponse, OnchainTierResponse,
-    OnchainTiersRequest, PaymentExecutionResponse, PaymentQuoteRequest, PaymentQuoteResponse,
-    PaymentsResponse, ReceiveRequestBolt11, StrikePaymentByIdResponse,
-    StrikeReceiveRequestResponse, StrikeReceivesWithCountResponse,
+    OnchainTiersRequest, Payment, PaymentExecutionResponse, PaymentQuoteRequest,
+    PaymentQuoteResponse, PaymentsResponse, ReceiveRequestBolt11, StrikePaymentByIdResponse,
+    StrikeReceive, StrikeReceiveRequestResponse, StrikeReceivesWithCountResponse,
 };
 use super::StrikeConfig;
 use crate::error_normalization::{
@@ -19,7 +20,8 @@ use crate::{
     ApiError, CreateInvoiceParams, InvoiceType, Offer, OnInvoiceEventCallback,
     OnInvoiceEventParams, OnchainFeePayer, OnchainFeePreference, OnchainFeePreferenceType,
     OnchainFeeSpeed, OnchainTransaction, PayInvoiceParams, PayInvoiceResponse, PayOnchainOptions,
-    PayOnchainResponse, PrepareOnchainTransactionParams, Transaction,
+    PayOnchainResponse, PrepareOnchainTransactionParams, SettlementState, SettlementType,
+    Transaction,
 };
 use reqwest::header;
 
@@ -144,6 +146,196 @@ fn amount_to_sats(amount: Option<&Amount>) -> Option<i64> {
         .parse::<f64>()
         .ok()
         .map(|btc| (btc * 100_000_000.0).round() as i64)
+}
+
+fn amount_to_msats(amount: Option<&Amount>) -> i64 {
+    amount_to_sats(amount).unwrap_or_default() * 1000
+}
+
+fn normalize_settlement_state(state: Option<&str>) -> SettlementState {
+    match state.map(str::to_ascii_uppercase).as_deref() {
+        Some("PENDING") => SettlementState::Pending,
+        Some("COMPLETED" | "SUCCESS") => SettlementState::Completed,
+        Some("FAILED" | "FAILURE") => SettlementState::Failed,
+        _ => SettlementState::Unknown,
+    }
+}
+
+fn normalize_settlement_type(
+    type_: Option<&str>,
+    state: Option<&str>,
+    has_lightning: bool,
+    has_onchain: bool,
+    has_p2p: bool,
+    txid: Option<&str>,
+) -> SettlementType {
+    let type_ = type_.map(str::to_ascii_uppercase);
+
+    if txid.is_some_and(|value| !value.is_empty()) {
+        SettlementType::Onchain
+    } else if matches!(type_.as_deref(), Some("P2P")) || has_p2p {
+        SettlementType::Intraledger
+    } else if matches!(type_.as_deref(), Some("LIGHTNING")) || has_lightning {
+        SettlementType::Lightning
+    } else if normalize_settlement_state(state) == SettlementState::Completed {
+        SettlementType::Intraledger
+    } else if matches!(type_.as_deref(), Some("ONCHAIN")) || has_onchain {
+        SettlementType::Onchain
+    } else {
+        SettlementType::Unknown
+    }
+}
+
+fn normalized_payment_id(payment: &Payment) -> Option<&str> {
+    payment.payment_id.as_deref().or(payment.id.as_deref())
+}
+
+fn parse_strike_payment_id(value: &str) -> Option<uuid::Uuid> {
+    let id = uuid::Uuid::parse_str(value).ok()?;
+    id.hyphenated()
+        .to_string()
+        .eq_ignore_ascii_case(value)
+        .then_some(id)
+}
+
+fn payment_to_transaction(payment: &Payment) -> Transaction {
+    let state = payment.state.as_deref().or(payment.result.as_deref());
+    let txid = payment
+        .onchain
+        .as_ref()
+        .and_then(|onchain| onchain.txn_id.clone())
+        .filter(|value| !value.trim().is_empty());
+
+    Transaction {
+        type_: "outgoing".to_string(),
+        invoice: payment
+            .lightning
+            .as_ref()
+            .and_then(|lightning| lightning.payment_request.clone())
+            .unwrap_or_default(),
+        description: payment.description.clone().unwrap_or_default(),
+        description_hash: String::new(),
+        preimage: payment
+            .lightning
+            .as_ref()
+            .and_then(|lightning| lightning.pre_image.clone())
+            .unwrap_or_default(),
+        payment_hash: payment
+            .lightning
+            .as_ref()
+            .and_then(|lightning| lightning.payment_hash.clone())
+            .unwrap_or_default(),
+        amount_msats: amount_to_msats(payment.amount.as_ref()),
+        fees_paid: payment
+            .lightning
+            .as_ref()
+            .and_then(|lightning| lightning.network_fee.as_ref())
+            .map(|fee| amount_to_msats(Some(fee)))
+            .unwrap_or_default(),
+        created_at: payment
+            .created
+            .as_deref()
+            .and_then(|created| chrono::DateTime::parse_from_rfc3339(created).ok())
+            .map(|created| created.timestamp())
+            .unwrap_or_default(),
+        expires_at: 0,
+        settled_at: if normalize_settlement_state(state) == SettlementState::Completed {
+            payment
+                .completed
+                .as_deref()
+                .and_then(|completed| chrono::DateTime::parse_from_rfc3339(completed).ok())
+                .map(|completed| completed.timestamp())
+                .unwrap_or_default()
+        } else {
+            0
+        },
+        payer_note: Some(String::new()),
+        external_id: normalized_payment_id(payment).map(str::to_string),
+        settlement_type: Some(normalize_settlement_type(
+            payment.type_.as_deref(),
+            state,
+            payment.lightning.is_some(),
+            payment.onchain.is_some(),
+            payment.p2p.is_some(),
+            txid.as_deref(),
+        )),
+        settlement_state: Some(normalize_settlement_state(state)),
+        txid,
+    }
+}
+
+fn receive_to_transaction(receive: &StrikeReceive) -> Transaction {
+    let txid = receive
+        .onchain
+        .as_ref()
+        .and_then(|onchain| {
+            onchain
+                .transaction_id
+                .clone()
+                .or_else(|| onchain.transaction_hash.clone())
+        })
+        .filter(|value| !value.trim().is_empty());
+    let lightning = receive.lightning.as_ref();
+
+    Transaction {
+        type_: "incoming".to_string(),
+        invoice: lightning
+            .map(|lightning| lightning.invoice.clone())
+            .unwrap_or_default(),
+        description: lightning
+            .and_then(|lightning| {
+                lightning
+                    .description
+                    .clone()
+                    .or_else(|| lightning.description_hash.clone())
+            })
+            .unwrap_or_default(),
+        description_hash: lightning
+            .and_then(|lightning| lightning.description_hash.clone())
+            .unwrap_or_default(),
+        preimage: lightning
+            .and_then(|lightning| lightning.preimage.clone())
+            .unwrap_or_default(),
+        payment_hash: lightning
+            .map(|lightning| lightning.payment_hash.clone())
+            .unwrap_or_default(),
+        amount_msats: amount_to_msats(Some(&receive.amount_received)),
+        fees_paid: 0,
+        created_at: receive
+            .created
+            .as_deref()
+            .and_then(|created| chrono::DateTime::parse_from_rfc3339(created).ok())
+            .map(|created| created.timestamp())
+            .unwrap_or_default(),
+        expires_at: 0,
+        settled_at: if normalize_settlement_state(receive.state.as_deref())
+            == SettlementState::Completed
+        {
+            receive
+                .completed
+                .as_deref()
+                .and_then(|completed| chrono::DateTime::parse_from_rfc3339(completed).ok())
+                .map(|completed| completed.timestamp())
+                .unwrap_or_default()
+        } else {
+            0
+        },
+        payer_note: Some(String::new()),
+        external_id: receive
+            .receive_id
+            .clone()
+            .or_else(|| receive.receive_request_id.clone()),
+        settlement_type: Some(normalize_settlement_type(
+            receive.type_.as_deref(),
+            receive.state.as_deref(),
+            receive.lightning.is_some(),
+            receive.onchain.is_some(),
+            receive.p2p.is_some(),
+            txid.as_deref(),
+        )),
+        settlement_state: Some(normalize_settlement_state(receive.state.as_deref())),
+        txid,
+    }
 }
 
 fn is_retryable_payment_read_status(status: reqwest::StatusCode) -> bool {
@@ -430,6 +622,9 @@ pub async fn create_invoice(
                 description_hash: invoice_params.description_hash.unwrap_or_default(),
                 payer_note: Some("".to_string()),
                 external_id: Some(receive_request_resp.receive_request_id),
+                settlement_type: None,
+                settlement_state: None,
+                txid: None,
             })
         }
         InvoiceType::Bolt12 => Err(ApiError::Json {
@@ -995,56 +1190,20 @@ pub async fn lookup_invoice(
             reason: format!("No receive found for payment hash: {}", target_payment_hash),
         })?;
 
-    let lightning_info = receive.lightning.ok_or_else(|| ApiError::Json {
+    receive.lightning.as_ref().ok_or_else(|| ApiError::Json {
         reason: "No lightning information in receive".to_string(),
     })?;
 
-    // Convert amount to millisatoshis
-    let amount_msats = if receive.amount_received.currency == "BTC" {
-        let btc_amount = receive.amount_received.amount.parse::<f64>().unwrap_or(0.0);
-        (btc_amount * 100_000_000_000.0) as i64
-    } else {
-        0
-    };
-
-    Ok(Transaction {
-        type_: "incoming".to_string(),
-        invoice: lightning_info.invoice,
-        preimage: lightning_info.preimage,
-        payment_hash: lightning_info.payment_hash,
-        amount_msats,
-        fees_paid: 0,
-        created_at: chrono::DateTime::parse_from_rfc3339(&receive.created)
-            .map(|dt| dt.timestamp())
-            .unwrap_or(0),
-        expires_at: 0, // Not available in receives response
-        settled_at: if receive.state == "COMPLETED" {
-            receive
-                .completed
-                .as_ref()
-                .and_then(|dt| chrono::DateTime::parse_from_rfc3339(dt).ok())
-                .map(|dt| dt.timestamp())
-                .unwrap_or(0)
-        } else {
-            0
-        },
-        description: lightning_info.description.unwrap_or_else(|| {
-            // If no description, use description_hash if available
-            lightning_info.description_hash.clone().unwrap_or_default()
-        }),
-        description_hash: lightning_info.description_hash.clone().unwrap_or_default(),
-        payer_note: Some("".to_string()),
-        external_id: Some(receive.receive_request_id),
-    })
+    Ok(receive_to_transaction(&receive))
 }
 
 pub async fn list_transactions(
     config: StrikeConfig,
-    from: i64,
-    limit: i64,
-    _search: Option<String>,
+    params: crate::ListTransactionsParams,
 ) -> Result<Vec<Transaction>, ApiError> {
     let client = async_client(&config)?;
+    let from = params.from;
+    let limit = params.limit;
 
     // Get receives (incoming) using the receives endpoint similar to lookup_invoice
     let receives_url = format!(
@@ -1059,7 +1218,7 @@ pub async fn list_transactions(
         .await
         .map_err(|e| strike_nwc_error_from_transport(e, "list_transactions"))?;
 
-    let mut transactions: Vec<Transaction> = Vec::new();
+    let mut transactions: HashMap<String, Transaction> = HashMap::new();
 
     if receives_response.status().is_success() {
         let receives_text = receives_response.text().await.unwrap();
@@ -1071,46 +1230,16 @@ pub async fn list_transactions(
             ),
         })?;
 
-        for receive in receives_resp.items {
-            if let Some(lightning_info) = receive.lightning {
-                // Convert amount to millisatoshis
-                let amount_msats = if receive.amount_received.currency == "BTC" {
-                    let btc_amount = receive.amount_received.amount.parse::<f64>().unwrap_or(0.0);
-                    (btc_amount * 100_000_000_000.0) as i64
-                } else {
-                    0
-                };
-
-                transactions.push(Transaction {
-                    type_: "incoming".to_string(),
-                    invoice: lightning_info.invoice,
-                    preimage: lightning_info.preimage,
-                    payment_hash: lightning_info.payment_hash,
-                    amount_msats,
-                    fees_paid: 0,
-                    created_at: chrono::DateTime::parse_from_rfc3339(&receive.created)
-                        .map(|dt| dt.timestamp())
-                        .unwrap_or(0),
-                    expires_at: 0, // Not available in receives response
-                    settled_at: if receive.state == "COMPLETED" {
-                        receive
-                            .completed
-                            .as_ref()
-                            .and_then(|dt| chrono::DateTime::parse_from_rfc3339(dt).ok())
-                            .map(|dt| dt.timestamp())
-                            .unwrap_or(0)
-                    } else {
-                        0
-                    },
-                    description: lightning_info.description.unwrap_or_else(|| {
-                        // If no description, use description_hash if available
-                        lightning_info.description_hash.clone().unwrap_or_default()
-                    }),
-                    description_hash: lightning_info.description_hash.clone().unwrap_or_default(),
-                    payer_note: Some("".to_string()),
-                    external_id: Some(receive.receive_request_id),
-                });
-            }
+        for (index, receive) in receives_resp.items.into_iter().enumerate() {
+            let transaction = receive_to_transaction(&receive);
+            let key = format!(
+                "incoming:{}",
+                transaction
+                    .external_id
+                    .clone()
+                    .unwrap_or_else(|| format!("receive-{index}"))
+            );
+            transactions.insert(key, transaction);
         }
     } else {
         let status = receives_response.status();
@@ -1125,7 +1254,7 @@ pub async fn list_transactions(
 
     // Get payments (outgoing)
     let payments_url = format!(
-        "{}/payments?skip={}&top={}",
+        "{}/payments?$skip={}&$top={}",
         get_base_url(&config),
         from,
         limit
@@ -1140,67 +1269,14 @@ pub async fn list_transactions(
         let payments_text = payments_response.text().await.unwrap();
         let payments_resp: PaymentsResponse = serde_json::from_str(&payments_text)?;
 
-        for payment in payments_resp.data {
-            let amount_msats = if payment.amount.currency == "BTC" {
-                let btc_amount = payment.amount.amount.parse::<f64>().unwrap_or(0.0);
-                (btc_amount * 100_000_000_000.0) as i64
-            } else {
-                0
-            };
-
-            let fee_msats = if let Some(lightning) = &payment.lightning {
-                if let Some(network_fee) = &lightning.network_fee {
-                    let fee_amount = network_fee.amount.parse::<f64>().unwrap_or(0.0);
-                    if network_fee.currency == "BTC" {
-                        (fee_amount * 100_000_000_000.0) as i64
-                    } else {
-                        0
-                    }
-                } else {
-                    0
-                }
-            } else {
-                0
-            };
-
-            transactions.push(Transaction {
-                type_: "outgoing".to_string(),
-                invoice: payment
-                    .lightning
-                    .as_ref()
-                    .and_then(|l| l.payment_request.clone())
-                    .unwrap_or_default(),
-                preimage: payment
-                    .lightning
-                    .as_ref()
-                    .and_then(|lightning| lightning.pre_image.clone())
-                    .unwrap_or_default(),
-                payment_hash: payment
-                    .lightning
-                    .as_ref()
-                    .and_then(|l| l.payment_hash.clone())
-                    .unwrap_or_default(),
-                amount_msats,
-                fees_paid: fee_msats,
-                created_at: chrono::DateTime::parse_from_rfc3339(&payment.created)
-                    .map(|dt| dt.timestamp())
-                    .unwrap_or(0),
-                expires_at: 0,
-                settled_at: if payment.state == "COMPLETED" {
-                    payment
-                        .completed
-                        .as_ref()
-                        .and_then(|dt| chrono::DateTime::parse_from_rfc3339(dt).ok())
-                        .map(|dt| dt.timestamp())
-                        .unwrap_or(0)
-                } else {
-                    0
-                },
-                description: payment.description.unwrap_or_default(),
-                description_hash: "".to_string(),
-                payer_note: Some("".to_string()),
-                external_id: Some(payment.id),
-            });
+        for (index, payment) in payments_resp.data.into_iter().enumerate() {
+            let key = format!(
+                "outgoing:{}",
+                normalized_payment_id(&payment)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("payment-{index}"))
+            );
+            transactions.insert(key, payment_to_transaction(&payment));
         }
     } else if payments_response.status() != reqwest::StatusCode::NOT_FOUND {
         let status = payments_response.status();
@@ -1213,8 +1289,51 @@ pub async fn list_transactions(
         ));
     }
 
-    // Sort by created date descending
+    if let Some(search) = params.search.as_deref().filter(|s| !s.is_empty()) {
+        if let Some(payment_id) = parse_strike_payment_id(search) {
+            let payment_url = format!("{}/payments/{}", get_base_url(&config), payment_id);
+            if let Ok(response) = client.get(&payment_url).send().await {
+                if response.status().is_success() {
+                    if let Ok(payment) = response.json::<Payment>().await {
+                        let key = format!(
+                            "outgoing:{}",
+                            normalized_payment_id(&payment).unwrap_or(search)
+                        );
+                        transactions.insert(key, payment_to_transaction(&payment));
+                    }
+                }
+            }
+        }
+    }
+
+    let mut transactions: Vec<Transaction> = transactions
+        .into_values()
+        .filter(|transaction| {
+            params
+                .payment_hash
+                .as_deref()
+                .map(|payment_hash| transaction.payment_hash == payment_hash)
+                .unwrap_or(true)
+                && params
+                    .search
+                    .as_deref()
+                    .map(|search| crate::transaction_matches_search(transaction, search))
+                    .unwrap_or(true)
+                && params
+                    .created_after
+                    .map(|created_after| transaction.created_at >= created_after)
+                    .unwrap_or(true)
+                && params
+                    .created_before
+                    .map(|created_before| transaction.created_at <= created_before)
+                    .unwrap_or(true)
+        })
+        .collect();
+
     transactions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    if limit > 0 {
+        transactions.truncate(limit as usize);
+    }
 
     Ok(transactions)
 }
@@ -1291,6 +1410,86 @@ pub async fn on_invoice_events(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+
+    const PAYMENT_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+    fn payment(value: serde_json::Value) -> Payment {
+        serde_json::from_value(value).expect("payment should deserialize")
+    }
+
+    fn receive(value: serde_json::Value) -> StrikeReceive {
+        serde_json::from_value(value).expect("receive should deserialize")
+    }
+
+    async fn test_server(
+        responses: Vec<(u16, serde_json::Value)>,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener.local_addr().expect("test server address");
+        let (sender, receiver) = mpsc::channel(responses.len());
+
+        tokio::spawn(async move {
+            for (status, response_body) in responses {
+                let (mut stream, _) = listener.accept().await.expect("request should connect");
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 4096];
+                loop {
+                    let read = stream.read(&mut buffer).await.expect("request should read");
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&request).into_owned();
+                sender
+                    .send(request)
+                    .await
+                    .expect("request should be recorded");
+
+                let body = response_body.to_string();
+                let reason = if status == 200 { "OK" } else { "Not Found" };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("response should write");
+            }
+        });
+
+        (format!("http://{address}"), receiver)
+    }
+
+    fn test_config(base_url: String) -> StrikeConfig {
+        StrikeConfig {
+            base_url: Some(base_url),
+            api_key: "test-token".to_string(),
+            socks5_proxy: None,
+            accept_invalid_certs: Some(false),
+            http_timeout: Some(5),
+        }
+    }
+
+    fn list_params(search: Option<&str>) -> crate::ListTransactionsParams {
+        crate::ListTransactionsParams {
+            from: 0,
+            limit: 10,
+            payment_hash: None,
+            search: search.map(str::to_string),
+            created_after: None,
+            created_before: None,
+        }
+    }
 
     #[test]
     fn proxy_client_builds_with_certificate_verification_enabled() {
@@ -1474,5 +1673,245 @@ mod tests {
         };
 
         assert!(assert_onchain_fee_guardrail(&test_onchain_transaction(None), options).is_ok());
+    }
+
+    #[test]
+    fn maps_outgoing_lifecycle_and_route_evidence_independently() {
+        let cases = [
+            (
+                serde_json::json!({ "id": "methodless-pending", "state": "PENDING" }),
+                SettlementType::Unknown,
+                SettlementState::Pending,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "methodless-completed", "state": "SUCCESS" }),
+                SettlementType::Intraledger,
+                SettlementState::Completed,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "p2p", "type": "P2P", "state": "PENDING", "p2p": {} }),
+                SettlementType::Intraledger,
+                SettlementState::Pending,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "direct", "type": "ONCHAIN", "state": "COMPLETED" }),
+                SettlementType::Intraledger,
+                SettlementState::Completed,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "waiting", "type": "ONCHAIN", "state": "PENDING", "onchain": {} }),
+                SettlementType::Onchain,
+                SettlementState::Pending,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "broadcast", "state": "PENDING", "onchain": { "txnId": "pending-txid" } }),
+                SettlementType::Onchain,
+                SettlementState::Pending,
+                Some("pending-txid"),
+            ),
+            (
+                serde_json::json!({ "id": "confirmed", "state": "COMPLETED", "onchain": { "txnId": "completed-txid" } }),
+                SettlementType::Onchain,
+                SettlementState::Completed,
+                Some("completed-txid"),
+            ),
+            (
+                serde_json::json!({ "id": "failed", "type": "ONCHAIN", "state": "FAILURE" }),
+                SettlementType::Onchain,
+                SettlementState::Failed,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "unknown", "state": "SOMETHING_NEW" }),
+                SettlementType::Unknown,
+                SettlementState::Unknown,
+                None,
+            ),
+            (
+                serde_json::json!({ "id": "lightning", "state": "COMPLETED", "lightning": { "paymentHash": "hash" } }),
+                SettlementType::Lightning,
+                SettlementState::Completed,
+                None,
+            ),
+        ];
+
+        for (value, expected_type, expected_state, expected_txid) in cases {
+            let transaction = payment_to_transaction(&payment(value));
+            assert_eq!(transaction.settlement_type, Some(expected_type));
+            assert_eq!(transaction.settlement_state, Some(expected_state));
+            assert_eq!(transaction.txid.as_deref(), expected_txid);
+        }
+    }
+
+    #[test]
+    fn p2p_lifecycle_updates_preserve_provider_id_and_route() {
+        let pending = payment_to_transaction(&payment(serde_json::json!({
+            "paymentId": PAYMENT_ID, "type": "P2P", "state": "PENDING", "p2p": {}
+        })));
+        let completed = payment_to_transaction(&payment(serde_json::json!({
+            "paymentId": PAYMENT_ID, "type": "P2P", "state": "COMPLETED", "p2p": {}
+        })));
+
+        assert_eq!(pending.external_id, completed.external_id);
+        assert_eq!(pending.settlement_type, Some(SettlementType::Intraledger));
+        assert_eq!(pending.settlement_state, Some(SettlementState::Pending));
+        assert_eq!(completed.settlement_type, Some(SettlementType::Intraledger));
+        assert_eq!(completed.settlement_state, Some(SettlementState::Completed));
+        assert!(pending.txid.is_none() && completed.txid.is_none());
+    }
+
+    #[test]
+    fn retains_incoming_p2p_and_onchain_receives() {
+        let p2p = receive_to_transaction(&receive(serde_json::json!({
+            "receiveId": "receive-p2p",
+            "receiveRequestId": "request-p2p",
+            "type": "P2P",
+            "state": "PENDING",
+            "amountReceived": { "amount": "0.00000001", "currency": "BTC" },
+            "p2p": { "payerAccountId": "payer" }
+        })));
+        let intraledger = receive_to_transaction(&receive(serde_json::json!({
+            "receiveId": "receive-direct",
+            "receiveRequestId": "request-direct",
+            "type": "ONCHAIN",
+            "state": "COMPLETED",
+            "amountReceived": { "amount": "0.00000001", "currency": "BTC" },
+            "onchain": { "address": "bc1q" }
+        })));
+        let onchain = receive_to_transaction(&receive(serde_json::json!({
+            "receiveId": "receive-chain",
+            "receiveRequestId": "request-chain",
+            "type": "ONCHAIN",
+            "state": "COMPLETED",
+            "amountReceived": { "amount": "0.00000001", "currency": "BTC" },
+            "onchain": { "address": "bc1q", "transactionId": "receive-txid" }
+        })));
+
+        assert_eq!(p2p.external_id.as_deref(), Some("receive-p2p"));
+        assert_eq!(p2p.settlement_type, Some(SettlementType::Intraledger));
+        assert_eq!(p2p.settlement_state, Some(SettlementState::Pending));
+        assert_eq!(
+            intraledger.settlement_type,
+            Some(SettlementType::Intraledger)
+        );
+        assert_eq!(
+            intraledger.settlement_state,
+            Some(SettlementState::Completed)
+        );
+        assert!(intraledger.txid.is_none());
+        assert_eq!(onchain.settlement_type, Some(SettlementType::Onchain));
+        assert_eq!(onchain.txid.as_deref(), Some("receive-txid"));
+    }
+
+    #[tokio::test]
+    async fn uuid_search_returns_direct_payment_outside_collection_page() {
+        let (base_url, mut requests) = test_server(vec![
+            (200, serde_json::json!({ "items": [], "count": 0 })),
+            (200, serde_json::json!({ "data": [], "count": 0 })),
+            (
+                200,
+                serde_json::json!({
+                    "paymentId": PAYMENT_ID,
+                    "state": "COMPLETED",
+                    "amount": { "amount": "0.00000001", "currency": "BTC" }
+                }),
+            ),
+        ])
+        .await;
+
+        let transactions = list_transactions(test_config(base_url), list_params(Some(PAYMENT_ID)))
+            .await
+            .expect("list transactions should succeed");
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].external_id.as_deref(), Some(PAYMENT_ID));
+        assert_eq!(
+            transactions[0].settlement_type,
+            Some(SettlementType::Intraledger)
+        );
+
+        let request_paths: Vec<String> = [
+            requests.recv().await,
+            requests.recv().await,
+            requests.recv().await,
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|request| request.lines().next().map(str::to_string))
+        .collect();
+        assert!(request_paths[2].contains(&format!("/payments/{PAYMENT_ID}")));
+    }
+
+    #[tokio::test]
+    async fn direct_snapshot_replaces_listed_copy_by_normalized_payment_id() {
+        let listed = serde_json::json!({
+            "id": PAYMENT_ID,
+            "state": "PENDING",
+            "created": "2026-01-01T00:00:00Z",
+            "amount": { "amount": "0.00000001", "currency": "BTC" }
+        });
+        let (base_url, _requests) = test_server(vec![
+            (200, serde_json::json!({ "items": [], "count": 0 })),
+            (200, serde_json::json!({ "data": [listed], "count": 1 })),
+            (
+                200,
+                serde_json::json!({
+                    "paymentId": PAYMENT_ID,
+                    "state": "COMPLETED",
+                    "amount": { "amount": "0.00000001", "currency": "BTC" }
+                }),
+            ),
+        ])
+        .await;
+
+        let transactions = list_transactions(test_config(base_url), list_params(Some(PAYMENT_ID)))
+            .await
+            .expect("list transactions should succeed");
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(
+            transactions[0].settlement_state,
+            Some(SettlementState::Completed)
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_404_falls_back_and_non_uuid_search_skips_direct_lookup() {
+        let listed = serde_json::json!({
+            "id": PAYMENT_ID,
+            "state": "PENDING",
+            "created": "2026-01-01T00:00:00Z",
+            "description": "reconciliation target",
+            "amount": { "amount": "0.00000001", "currency": "BTC" }
+        });
+        let (base_url, _requests) = test_server(vec![
+            (200, serde_json::json!({ "items": [], "count": 0 })),
+            (
+                200,
+                serde_json::json!({ "data": [listed.clone()], "count": 1 }),
+            ),
+            (404, serde_json::json!({ "message": "not found" })),
+        ])
+        .await;
+        let fallback = list_transactions(test_config(base_url), list_params(Some(PAYMENT_ID)))
+            .await
+            .expect("404 should fall back");
+        assert_eq!(fallback.len(), 1);
+
+        let (base_url, mut requests) = test_server(vec![
+            (200, serde_json::json!({ "items": [], "count": 0 })),
+            (200, serde_json::json!({ "data": [listed], "count": 1 })),
+        ])
+        .await;
+        let text_search = list_transactions(test_config(base_url), list_params(Some("TARGET")))
+            .await
+            .expect("text search should succeed");
+        assert_eq!(text_search.len(), 1);
+        assert!(requests.recv().await.is_some());
+        assert!(requests.recv().await.is_some());
+        assert!(requests.recv().await.is_none());
     }
 }

--- a/crates/lni/strike/api.rs
+++ b/crates/lni/strike/api.rs
@@ -190,6 +190,66 @@ fn normalized_payment_id(payment: &Payment) -> Option<&str> {
     payment.payment_id.as_deref().or(payment.id.as_deref())
 }
 
+fn merge_payment_snapshots(mut listed: Payment, direct: Payment) -> Payment {
+    let direct_has_lifecycle = direct.state.is_some() || direct.result.is_some();
+
+    macro_rules! replace_if_some {
+        ($field:ident) => {
+            if direct.$field.is_some() {
+                listed.$field = direct.$field;
+            }
+        };
+    }
+
+    replace_if_some!(id);
+    replace_if_some!(payment_id);
+    replace_if_some!(type_);
+    replace_if_some!(amount);
+    replace_if_some!(total_fee);
+    replace_if_some!(total_amount);
+    replace_if_some!(created);
+    replace_if_some!(completed);
+    replace_if_some!(correlation_id);
+    replace_if_some!(description);
+    replace_if_some!(p2p);
+
+    if direct_has_lifecycle {
+        listed.state = direct.state;
+        listed.result = direct.result;
+    }
+
+    if let Some(direct_lightning) = direct.lightning {
+        if let Some(listed_lightning) = listed.lightning.as_mut() {
+            if direct_lightning.network_fee.is_some() {
+                listed_lightning.network_fee = direct_lightning.network_fee;
+            }
+            if direct_lightning.payment_hash.is_some() {
+                listed_lightning.payment_hash = direct_lightning.payment_hash;
+            }
+            if direct_lightning.payment_request.is_some() {
+                listed_lightning.payment_request = direct_lightning.payment_request;
+            }
+            if direct_lightning.pre_image.is_some() {
+                listed_lightning.pre_image = direct_lightning.pre_image;
+            }
+        } else {
+            listed.lightning = Some(direct_lightning);
+        }
+    }
+
+    if let Some(direct_onchain) = direct.onchain {
+        if let Some(listed_onchain) = listed.onchain.as_mut() {
+            if direct_onchain.txn_id.is_some() {
+                listed_onchain.txn_id = direct_onchain.txn_id;
+            }
+        } else {
+            listed.onchain = Some(direct_onchain);
+        }
+    }
+
+    listed
+}
+
 fn parse_strike_payment_id(value: &str) -> Option<uuid::Uuid> {
     let id = uuid::Uuid::parse_str(value).ok()?;
     id.hyphenated()
@@ -1219,6 +1279,7 @@ pub async fn list_transactions(
         .map_err(|e| strike_nwc_error_from_transport(e, "list_transactions"))?;
 
     let mut transactions: HashMap<String, Transaction> = HashMap::new();
+    let mut payments: HashMap<String, Payment> = HashMap::new();
 
     if receives_response.status().is_success() {
         let receives_text = receives_response.text().await.unwrap();
@@ -1276,7 +1337,7 @@ pub async fn list_transactions(
                     .map(str::to_string)
                     .unwrap_or_else(|| format!("payment-{index}"))
             );
-            transactions.insert(key, payment_to_transaction(&payment));
+            payments.insert(key, payment);
         }
     } else if payments_response.status() != reqwest::StatusCode::NOT_FOUND {
         let status = payments_response.status();
@@ -1299,11 +1360,19 @@ pub async fn list_transactions(
                             "outgoing:{}",
                             normalized_payment_id(&payment).unwrap_or(search)
                         );
-                        transactions.insert(key, payment_to_transaction(&payment));
+                        let payment = match payments.remove(&key) {
+                            Some(listed) => merge_payment_snapshots(listed, payment),
+                            None => payment,
+                        };
+                        payments.insert(key, payment);
                     }
                 }
             }
         }
+    }
+
+    for (key, payment) in payments {
+        transactions.insert(key, payment_to_transaction(&payment));
     }
 
     let mut transactions: Vec<Transaction> = transactions
@@ -1330,7 +1399,25 @@ pub async fn list_transactions(
         })
         .collect();
 
-    transactions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    transactions.sort_by(|a, b| {
+        b.created_at
+            .cmp(&a.created_at)
+            .then_with(|| a.type_.cmp(&b.type_))
+            .then_with(|| {
+                a.external_id
+                    .as_deref()
+                    .unwrap_or_default()
+                    .cmp(b.external_id.as_deref().unwrap_or_default())
+            })
+            .then_with(|| a.payment_hash.cmp(&b.payment_hash))
+            .then_with(|| {
+                a.txid
+                    .as_deref()
+                    .unwrap_or_default()
+                    .cmp(b.txid.as_deref().unwrap_or_default())
+            })
+            .then_with(|| a.invoice.cmp(&b.invoice))
+    });
     if limit > 0 {
         transactions.truncate(limit as usize);
     }
@@ -1847,12 +1934,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_snapshot_replaces_listed_copy_by_normalized_payment_id() {
+    async fn direct_snapshot_preserves_omitted_fields_from_listed_copy() {
         let listed = serde_json::json!({
             "id": PAYMENT_ID,
+            "type": "ONCHAIN",
             "state": "PENDING",
             "created": "2026-01-01T00:00:00Z",
-            "amount": { "amount": "0.00000001", "currency": "BTC" }
+            "description": "listed description",
+            "amount": { "amount": "0.00000001", "currency": "BTC" },
+            "onchain": { "txnId": "listed-txid" }
         });
         let (base_url, _requests) = test_server(vec![
             (200, serde_json::json!({ "items": [], "count": 0 })),
@@ -1862,7 +1952,7 @@ mod tests {
                 serde_json::json!({
                     "paymentId": PAYMENT_ID,
                     "state": "COMPLETED",
-                    "amount": { "amount": "0.00000001", "currency": "BTC" }
+                    "completed": "2026-01-01T00:01:00Z"
                 }),
             ),
         ])
@@ -1872,10 +1962,51 @@ mod tests {
             .await
             .expect("list transactions should succeed");
         assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].amount_msats, 1_000);
+        assert_eq!(transactions[0].created_at, 1_767_225_600);
+        assert_eq!(transactions[0].settled_at, 1_767_225_660);
+        assert_eq!(transactions[0].description, "listed description");
+        assert_eq!(transactions[0].txid.as_deref(), Some("listed-txid"));
+        assert_eq!(
+            transactions[0].settlement_type,
+            Some(SettlementType::Onchain)
+        );
         assert_eq!(
             transactions[0].settlement_state,
             Some(SettlementState::Completed)
         );
+    }
+
+    #[tokio::test]
+    async fn transaction_limit_uses_deterministic_identifier_tie_breaker() {
+        let payments = serde_json::json!([
+            {
+                "id": "payment-z",
+                "state": "PENDING",
+                "created": "2026-01-01T00:00:00Z",
+                "amount": { "amount": "0.00000001", "currency": "BTC" }
+            },
+            {
+                "id": "payment-a",
+                "state": "PENDING",
+                "created": "2026-01-01T00:00:00Z",
+                "amount": { "amount": "0.00000001", "currency": "BTC" }
+            }
+        ]);
+        let (base_url, _requests) = test_server(vec![
+            (200, serde_json::json!({ "items": [], "count": 0 })),
+            (200, serde_json::json!({ "data": payments, "count": 2 })),
+        ])
+        .await;
+        let mut params = list_params(None);
+        params.limit = 1;
+
+        let transactions = list_transactions(test_config(base_url), params)
+            .await
+            .expect("list transactions should succeed");
+
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].external_id.as_deref(), Some("payment-a"));
     }
 
     #[tokio::test]

--- a/crates/lni/strike/lib.rs
+++ b/crates/lni/strike/lib.rs
@@ -141,13 +141,7 @@ impl StrikeNode {
         &self,
         params: ListTransactionsParams,
     ) -> Result<Vec<crate::Transaction>, ApiError> {
-        crate::strike::api::list_transactions(
-            self.config.clone(),
-            params.from,
-            params.limit,
-            params.search,
-        )
-        .await
+        crate::strike::api::list_transactions(self.config.clone(), params).await
     }
 
     pub async fn decode(&self, str: String) -> Result<String, ApiError> {

--- a/crates/lni/strike/types.rs
+++ b/crates/lni/strike/types.rs
@@ -119,15 +119,25 @@ pub struct InvoiceQuoteResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct Payment {
-    pub id: String,
-    pub amount: Amount,
-    pub state: String, // "PENDING", "COMPLETED", "FAILED"
-    pub created: String,
+    pub id: Option<String>,
+    #[serde(rename = "paymentId")]
+    pub payment_id: Option<String>,
+    #[serde(rename = "type")]
+    pub type_: Option<String>,
+    pub state: Option<String>,
+    pub result: Option<String>,
+    pub amount: Option<Amount>,
+    #[serde(rename = "totalFee")]
+    pub total_fee: Option<Amount>,
+    #[serde(rename = "totalAmount")]
+    pub total_amount: Option<Amount>,
+    pub created: Option<String>,
     pub completed: Option<String>,
     pub correlation_id: Option<String>,
     pub description: Option<String>,
     pub lightning: Option<LightningPayment>,
     pub onchain: Option<OnchainPayment>,
+    pub p2p: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -282,20 +292,7 @@ pub struct OnchainPaymentExecutionResponse {
     pub onchain: Option<OnchainDetails>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct StrikePaymentByIdResponse {
-    #[serde(rename = "paymentId")]
-    pub payment_id: Option<String>,
-    pub id: Option<String>,
-    pub state: Option<String>,
-    pub created: Option<String>,
-    pub amount: Option<Amount>,
-    #[serde(rename = "totalFee")]
-    pub total_fee: Option<Amount>,
-    #[serde(rename = "totalAmount")]
-    pub total_amount: Option<Amount>,
-    pub onchain: Option<OnchainDetails>,
-}
+pub type StrikePaymentByIdResponse = Payment;
 
 #[derive(Debug, Deserialize)]
 pub struct PaymentExecution {
@@ -453,30 +450,53 @@ pub struct StrikeReceivesWithCountResponse {
 #[derive(Debug, Deserialize)]
 pub struct StrikeReceive {
     #[serde(rename = "receiveId")]
-    pub receive_id: String,
+    pub receive_id: Option<String>,
     #[serde(rename = "receiveRequestId")]
-    pub receive_request_id: String,
+    pub receive_request_id: Option<String>,
     #[serde(rename = "type")]
-    pub type_: String, // "LIGHTNING", "ONCHAIN"
-    pub state: String, // "COMPLETED", "PENDING", etc.
+    pub type_: Option<String>, // "LIGHTNING", "ONCHAIN", "P2P"
+    pub state: Option<String>, // "COMPLETED", "PENDING", etc.
     #[serde(rename = "amountReceived")]
     pub amount_received: Amount,
     #[serde(rename = "amountCredited")]
-    pub amount_credited: Amount,
-    pub created: String,
+    pub amount_credited: Option<Amount>,
+    pub created: Option<String>,
     pub completed: Option<String>,
     pub lightning: Option<StrikeReceiveLightning>,
+    pub onchain: Option<StrikeReceiveOnchain>,
+    pub p2p: Option<StrikeReceiveP2p>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct StrikeReceiveLightning {
     pub invoice: String,
-    pub preimage: String,
+    pub preimage: Option<String>,
     pub description: Option<String>,
     #[serde(rename = "descriptionHash")]
     pub description_hash: Option<String>,
     #[serde(rename = "paymentHash")]
     pub payment_hash: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StrikeReceiveOnchain {
+    pub address: Option<String>,
+    #[serde(rename = "transactionId")]
+    pub transaction_id: Option<String>,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<String>,
+    #[serde(rename = "outputIndex")]
+    pub output_index: Option<i64>,
+    #[serde(rename = "blockHeight")]
+    pub block_height: Option<i64>,
+    #[serde(rename = "numberOfConfirmations")]
+    pub number_of_confirmations: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StrikeReceiveP2p {
+    #[serde(rename = "payerAccountId")]
+    pub payer_account_id: Option<String>,
 }
 
 // Strike API lookup response for receive requests (returns items array)

--- a/crates/lni/types.rs
+++ b/crates/lni/types.rs
@@ -164,6 +164,64 @@ pub struct Transaction {
     pub settled_at: i64, // 0 means not paid yet TODO maybe add status field
     pub payer_note: Option<String>, // used in bolt12 (on phoenixd)
     pub external_id: Option<String>, // used in bolt11 (on phoenixd)
+    #[serde(default)]
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub settlement_type: Option<SettlementType>,
+    #[serde(default)]
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub settlement_state: Option<SettlementState>,
+    #[serde(default)]
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub txid: Option<String>,
+}
+
+#[cfg_attr(feature = "napi_rs", napi(string_enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(not(feature = "napi_rs"), derive(Clone))]
+#[serde(rename_all = "lowercase")]
+pub enum SettlementType {
+    Lightning,
+    Onchain,
+    Intraledger,
+    Unknown,
+}
+
+#[cfg_attr(feature = "napi_rs", napi(string_enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(not(feature = "napi_rs"), derive(Clone))]
+#[serde(rename_all = "lowercase")]
+pub enum SettlementState {
+    Pending,
+    Completed,
+    Failed,
+    Unknown,
+}
+
+pub fn transaction_matches_search(transaction: &Transaction, search: &str) -> bool {
+    let search = search.to_lowercase();
+    transaction.payment_hash.to_lowercase().contains(&search)
+        || transaction.invoice.to_lowercase().contains(&search)
+        || transaction.description.to_lowercase().contains(&search)
+        || transaction
+            .payer_note
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase()
+            .contains(&search)
+        || transaction
+            .external_id
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase()
+            .contains(&search)
+        || transaction
+            .txid
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase()
+            .contains(&search)
 }
 
 #[cfg_attr(feature = "napi_rs", napi(object))]
@@ -669,5 +727,75 @@ impl Default for OnInvoiceEventParams {
             polling_delay_sec: 5,
             max_polling_sec: 60,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transaction() -> Transaction {
+        Transaction {
+            type_: "incoming".to_string(),
+            invoice: "LN-INVOICE".to_string(),
+            description: "Coffee Beans".to_string(),
+            description_hash: String::new(),
+            preimage: String::new(),
+            payment_hash: "HASH-ABC".to_string(),
+            amount_msats: 1_000,
+            fees_paid: 0,
+            created_at: 0,
+            expires_at: 0,
+            settled_at: 0,
+            payer_note: Some("Table Seven".to_string()),
+            external_id: Some("EXTERNAL-ID".to_string()),
+            settlement_type: Some(SettlementType::Intraledger),
+            settlement_state: Some(SettlementState::Completed),
+            txid: Some("BITCOIN-TXID".to_string()),
+        }
+    }
+
+    #[test]
+    fn transaction_search_matches_all_text_identifiers_case_insensitively() {
+        let transaction = transaction();
+        for search in [
+            "invoice",
+            "hash-a",
+            "COFFEE",
+            "seven",
+            "external",
+            "bitcoin-tx",
+        ] {
+            assert!(transaction_matches_search(&transaction, search));
+        }
+    }
+
+    #[test]
+    fn settlement_enums_serde_round_trip_as_lowercase_strings() {
+        let json = serde_json::to_string(&transaction()).expect("transaction should serialize");
+        assert!(json.contains(r#""settlement_type":"intraledger""#));
+        assert!(json.contains(r#""settlement_state":"completed""#));
+
+        let decoded: Transaction =
+            serde_json::from_str(&json).expect("transaction should deserialize");
+        assert_eq!(decoded.settlement_type, Some(SettlementType::Intraledger));
+        assert_eq!(decoded.settlement_state, Some(SettlementState::Completed));
+    }
+
+    #[test]
+    fn settlement_fields_default_when_deserializing_legacy_transactions() {
+        let mut value = serde_json::to_value(transaction()).expect("transaction should serialize");
+        let object = value
+            .as_object_mut()
+            .expect("transaction should be an object");
+        object.remove("settlement_type");
+        object.remove("settlement_state");
+        object.remove("txid");
+
+        let decoded: Transaction =
+            serde_json::from_value(value).expect("legacy transaction should deserialize");
+        assert!(decoded.settlement_type.is_none());
+        assert!(decoded.settlement_state.is_none());
+        assert!(decoded.txid.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Adds Strike transaction reconciliation across the Rust and TypeScript implementations.

Callers can now reconcile the `paymentId` returned by `payOnchain()` using:

```ts
const [transaction] = await node.listTransactions({
  from: 0,
  limit: 1,
  search: paymentId,
})
```

## Changes
- Added optional transaction settlement metadata to Transaction type:
  - settlementType: lightning, onchain, intraledger, or unknown
  - settlementState: pending, completed, failed, or unknown
  - txid: present only when supplied by Strike
- Added equivalent public Rust enums and optional Transaction fields.
- Added support for incoming Strike P2P and onchain receives.
- Preserved redirect: 'error' as the default TypeScript request policy while removing the React Native capability flag and blanket runtime rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transactions now include optional settlement type, settlement state, and transaction ID details.
  - Transaction searches also match external IDs and transaction IDs.
  - Strike transaction history now supports improved reconciliation, lifecycle mapping, filtering, sorting, and direct payment lookup.
  - Strike transactions include richer support for Lightning, on-chain, and peer-to-peer payments.

- **Bug Fixes**
  - Improved preservation of transaction details when combining Strike payment records.
  - Corrected Strike payment pagination behavior.

- **Documentation**
  - Updated React Native guidance for redirect-capable fetch implementations.

- **Breaking Changes**
  - Removed the `fetchSupportsRedirectError` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->